### PR TITLE
fix: permission system fixes and v1.0.3 release

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,9 +1,210 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
-    // Open rules for emulator testing
+    
+    // --- Helper Functions ---
+    
+    function isSignedIn() {
+      return request.auth != null;
+    }
+    
+    function isOwner(userId) {
+      return request.auth.uid == userId;
+    }
+    
+    // Check if the user is a member of the clinic
+    function isClinicMember(clinicId) {
+      return isSignedIn() && exists(/databases/$(database)/documents/clinics/$(clinicId)/members/$(request.auth.uid));
+    }
+
+    // Check strict granular permission
+    // This requires reading the member document.
+    // We assume the member document has a 'permissions' array field.
+    function hasPermission(clinicId, permission) {
+      // 1. Must be signed in
+      // 2. Must be a member
+      // 3. Must have specific permission OR be the Owner (role == 'owner')
+      // Note: We use get() to fetch the member data.
+      let memberPath = /databases/$(database)/documents/clinics/$(clinicId)/members/$(request.auth.uid);
+      let memberData = get(memberPath).data;
+      
+      return isSignedIn() && 
+             exists(memberPath) && (
+               memberData.role == 'owner' || 
+               (memberData.permissions is list && memberData.permissions.hasAny([permission]))
+             );
+    }
+    
+    // --- Collection Rules ---
+
+    // Users & Owners
+    match /users/{userId} {
+      allow read: if isSignedIn();
+      allow write: if isOwner(userId);
+      match /{document=**} {
+         allow read, write: if isOwner(userId);
+      }
+    }
+
+    // Clinics -> Members
+    match /clinics/{clinicId} {
+      allow read: if isClinicMember(clinicId);
+      allow write: if hasPermission(clinicId, 'manageSettings');
+
+      match /members/{memberId} {
+        allow read: if isClinicMember(clinicId);
+        // Only admins/owners with manageStaff permission can write members
+        allow write: if hasPermission(clinicId, 'manageStaff');
+      }
+      
+       // Patients (subcollection style if used)
+      match /patients/{patientId} {
+        allow read: if hasPermission(clinicId, 'viewAllPatients') || hasPermission(clinicId, 'viewOwnPatients');
+        allow create: if hasPermission(clinicId, 'createPatient');
+        allow update: if hasPermission(clinicId, 'updatePatient');
+        allow delete: if hasPermission(clinicId, 'deletePatient');
+      }
+    }
+
+    // Global Patients (Root Collection)
+    match /patients/{patientId} {
+      allow read: if hasPermission(resource.data.clinicId, 'viewAllPatients') || hasPermission(resource.data.clinicId, 'viewOwnPatients');
+      allow create: if hasPermission(request.resource.data.clinicId, 'createPatient');
+      allow update: if hasPermission(resource.data.clinicId, 'updatePatient');
+      allow delete: if hasPermission(resource.data.clinicId, 'deletePatient');
+    }
+
+    // Medical Files
+    // Assoc with Patient? Assuming top-level or subcollection. 
+    // If top level, it needs clinicId field.
+    // If subcollection of patient, it inherits rules? No, Firestore rules don't inherit.
+    // Assuming structure: /medical_files/{fileId} with clinicId field.
+    match /medical_files/{fileId} {
+      allow read: if hasPermission(resource.data.clinicId, 'viewMedicalFiles');
+      allow create: if hasPermission(request.resource.data.clinicId, 'addMedicalFile');
+      allow update: if hasPermission(resource.data.clinicId, 'editMedicalFile');
+      allow delete: if hasPermission(resource.data.clinicId, 'deleteMedicalFile');
+    }
+
+    // Medications
+    match /medications/{medId} {
+      allow read: if hasPermission(resource.data.clinicId, 'viewMedications');
+      allow create: if hasPermission(request.resource.data.clinicId, 'addMedication');
+      allow update: if hasPermission(resource.data.clinicId, 'editMedication');
+      allow delete: if hasPermission(resource.data.clinicId, 'deleteMedication');
+    }
+
+    // Financials (Invoices, Bills)
+    match /invoices/{invoiceId} {
+      allow read: if hasPermission(resource.data.clinicId, 'viewFinancials');
+      allow create: if hasPermission(request.resource.data.clinicId, 'addFinancialEntry');
+      allow update: if hasPermission(resource.data.clinicId, 'editFinancialEntry');
+      allow delete: if hasPermission(resource.data.clinicId, 'deleteFinancialEntry');
+    }
+    match /bills/{billId} {
+      allow read: if hasPermission(resource.data.clinicId, 'viewFinancials');
+      allow create: if hasPermission(request.resource.data.clinicId, 'addFinancialEntry');
+      allow update: if hasPermission(resource.data.clinicId, 'editFinancialEntry');
+      allow delete: if hasPermission(resource.data.clinicId, 'deleteFinancialEntry');
+    }
+    match /transactions/{txnId} {
+      allow read: if hasPermission(resource.data.clinicId, 'viewFinancials');
+      allow create: if hasPermission(request.resource.data.clinicId, 'addFinancialEntry');
+      allow update: if hasPermission(resource.data.clinicId, 'editFinancialEntry');
+      allow delete: if hasPermission(resource.data.clinicId, 'deleteFinancialEntry');
+    }
+
+    // Clinical Reports
+    match /clinical_reports/{reportId} {
+      allow read: if hasPermission(resource.data.clinicId, 'viewClinicalReports');
+      allow create: if hasPermission(request.resource.data.clinicId, 'addClinicalReport');
+      allow update: if hasPermission(resource.data.clinicId, 'editClinicalReport');
+      allow delete: if hasPermission(resource.data.clinicId, 'deleteClinicalReport');
+    }
+
+    // Doctors
+    match /doctors/{doctorId} {
+      allow read: if hasPermission(resource.data.clinicId, 'viewDoctors');
+      allow write: if hasPermission(resource.data.clinicId, 'manageDoctors'); // includes create/update/delete
+    }
+
+    // Invitations
+    match /user_invitations/{inviteId} {
+      // Create/Send
+      allow create: if hasPermission(request.resource.data.clinicId, 'sendInvitation');
+      // Revoke/Delete
+      allow delete: if hasPermission(resource.data.clinicId, 'revokeInvitation');
+      // View/List
+      allow read: if hasPermission(resource.data.clinicId, 'viewInvitations');
+      // Allow user see their own invites by email
+      allow read: if isSignedIn() && resource.data.email == request.auth.token.email;
+    }
+
+    // Staff
+    match /staff/{staffId} {
+      allow read: if isClinicMember(resource.data.clinicId); // Public to clinic usually
+      allow write: if hasPermission(resource.data.clinicId, 'manageStaff');
+    }
+
+    // Team/Chat
+    match /team_conversations/{chatId} {
+       allow read, write: if isClinicMember(resource.data.clinicId);
+       match /messages/{msgId} {
+          allow read, write: if isClinicMember(get(/databases/$(database)/documents/team_conversations/$(chatId)).data.clinicId);
+       }
+    }
+
+    // Calendar
+    match /calendar_events/{eventId} {
+       allow read: if hasPermission(resource.data.clinicId, 'viewCalendar');
+       allow create: if hasPermission(request.resource.data.clinicId, 'addCalendarEvent');
+       allow update: if hasPermission(resource.data.clinicId, 'editCalendarEvent');
+       allow delete: if hasPermission(resource.data.clinicId, 'deleteCalendarEvent');
+    }
+
+    // Evaluation/Sessions (Standard)
+    match /sessions/{sessionId} {
+       allow read: if hasPermission(resource.data.clinicId, 'viewAllSessions');
+       allow write: if hasPermission(resource.data.clinicId, 'createSession'); // Simplification
+    }
+    match /evaluations/{evalId} {
+       allow read: if hasPermission(resource.data.clinicId, 'viewAllEvaluations');
+       allow write: if hasPermission(resource.data.clinicId, 'createEvaluation'); // Simplification
+    }
+
+    // Specific fallback for Recycle Bin? 
+    // Recycle bin items usually stay in their original collection with a 'deleted' flag 
+    // OR move to a separate collection.
+    // If separate:
+    match /recycle_bin/{itemId} {
+       allow read: if hasPermission(resource.data.clinicId, 'viewRecycleBin');
+       allow delete: if hasPermission(resource.data.clinicId, 'permanentDeleteRecycleBinItem'); // Permanent delete
+       allow update: if hasPermission(resource.data.clinicId, 'restoreRecycleBinItem'); // Restore (often involves move or flag update)
+    }
+
+    // AI Copilot Conversations (Chat History)
+    match /conversations/{conversationId} {
+       // Users can read/write their own conversations
+       allow read, write: if isSignedIn() && resource.data.userId == request.auth.uid;
+       allow create: if isSignedIn() && request.resource.data.userId == request.auth.uid;
+       
+       // Messages subcollection
+       match /messages/{messageId} {
+          allow read, write: if isSignedIn() && get(/databases/$(database)/documents/conversations/$(conversationId)).data.userId == request.auth.uid;
+       }
+    }
+
+    // Teams Collection (Custom Teams)
+    match /custom_teams/{teamId} {
+       allow read: if isClinicMember(resource.data.clinicId);
+       allow create: if hasPermission(request.resource.data.clinicId, 'createTeam');
+       allow update: if hasPermission(resource.data.clinicId, 'manageTeams');
+       allow delete: if hasPermission(resource.data.clinicId, 'archiveTeam');
+    }
+
+    // Default Deny
     match /{document=**} {
-      allow read, write: if true;
+      allow read, write: if false;
     }
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,7 @@ import 'package:easy_localization/easy_localization.dart' as localization;
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:dr_copilot/src/core/services/remote_config_service.dart';
 import 'src/core/injections.dart';
 import 'src/core/services/fcm_service.dart';
 import 'firebase_options.dart';
@@ -43,6 +44,14 @@ void main() async {
     // Initialize dependency injections for the app
     // This is where you set up your service locator (GetIt) and register all the necessary services.
     await initInjections();
+
+    // Initialize Remote Config (Feature Flags)
+    try {
+      await sl<RemoteConfigService>().initialize();
+    } catch (e) {
+      debugPrint('Warning: Remote Config initialization failed: $e');
+    }
+
     // await OwnerNotifier().loadOwnerIdAndClinicId(); // Removed: Handled by App BlocListener
     final secureStorage = FlutterSecureStorage();
 

--- a/lib/main_permission_migration.dart
+++ b/lib/main_permission_migration.dart
@@ -1,0 +1,234 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:dr_copilot/firebase_options.dart';
+
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp(
+    options: DefaultFirebaseOptions.currentPlatform,
+  );
+
+  runApp(const MigrationApp());
+}
+
+class MigrationApp extends StatelessWidget {
+  const MigrationApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(title: const Text('Permission Migration Tool')),
+        body: const MigrationRunner(),
+      ),
+    );
+  }
+}
+
+class MigrationRunner extends StatefulWidget {
+  const MigrationRunner({super.key});
+
+  @override
+  State<MigrationRunner> createState() => _MigrationRunnerState();
+}
+
+class _MigrationRunnerState extends State<MigrationRunner> {
+  String _status = 'Ready to migrate permissions.';
+  bool _isLoading = false;
+
+  // Full permissions for Owners
+  final List<String> _allPermissions = [
+    // Medical Files
+    'viewMedicalFiles',
+    'addMedicalFile',
+    'editMedicalFile',
+    'deleteMedicalFile',
+    // Medications
+    'viewMedications',
+    'addMedication',
+    'editMedication',
+    'deleteMedication',
+    // Recycle Bin
+    'viewRecycleBin',
+    'restoreRecycleBinItem',
+    'permanentDeleteRecycleBinItem',
+    // Financials
+    'addFinancialEntry',
+    'editFinancialEntry',
+    'deleteFinancialEntry',
+    'viewFinancials',
+    // Clinical Reports
+    'viewClinicalReports',
+    'addClinicalReport',
+    'editClinicalReport',
+    'deleteClinicalReport',
+    // Doctors
+    'viewDoctors',
+    'manageDoctors',
+    // Invitations
+    'viewInvitations',
+    'sendInvitation',
+    'revokeInvitation',
+    // Subscription
+    'viewSubscription',
+    'manageSubscription',
+    // Admin
+    'manageStaff',
+    'manageUsers',
+    'assignRoles',
+    'assignPermissions',
+    'manageSettings',
+  ];
+
+  // Specific permissions for Doctors
+  final List<String> _doctorPermissions = [
+    'viewMedicalFiles',
+    'addMedicalFile',
+    'editMedicalFile',
+    'viewMedications',
+    'addMedication',
+    'editMedication',
+    'viewRecycleBin', // Maybe restrictive?
+    'viewClinicalReports',
+    'addClinicalReport',
+    'editClinicalReport',
+    'viewDoctors',
+    'viewAllPatients',
+    'createPatient',
+    'updatePatient',
+    'createSession',
+    'viewAllSessions',
+    'createEvaluation',
+    'viewAllEvaluations',
+  ];
+
+  // Specific permissions for Staff (General)
+  final List<String> _staffPermissions = [
+    'viewMedicalFiles',
+    'addMedicalFile',
+    'viewMedications',
+    'viewDoctors',
+    'viewAllPatients',
+    'createPatient',
+    'updatePatient',
+    'viewAllSessions', // maybe restrictive
+  ];
+
+  Future<void> _runMigration() async {
+    setState(() {
+      _isLoading = true;
+      _status = 'Starting migration...';
+    });
+
+    try {
+      final firestore = FirebaseFirestore.instance;
+      int ownersUpdated = 0;
+      int membersUpdated = 0;
+
+      // 1. Update Users (Global Owners)
+      _status = 'Updating Owners (users collection)...';
+      final usersSnapshot = await firestore.collection('users').get();
+
+      for (var doc in usersSnapshot.docs) {
+        // Owners get ALL permissions
+        await _updateDocumentPermissions(
+            doc.reference, doc.data(), _allPermissions);
+        ownersUpdated++;
+      }
+
+      // 2. Update Clinic Members (Doctors, Staff, etc.)
+      _status = 'Updating Clinic Members...';
+      final clinicsSnapshot = await firestore.collection('clinics').get();
+
+      for (var clinicDoc in clinicsSnapshot.docs) {
+        final membersSnapshot =
+            await clinicDoc.reference.collection('members').get();
+
+        for (var memberDoc in membersSnapshot.docs) {
+          final data = memberDoc.data();
+          final role = (data['role'] as String?)?.toLowerCase() ?? '';
+
+          List<String> targetPermissions = [];
+
+          if (role == 'owner') {
+            targetPermissions = _allPermissions;
+          } else if (role == 'doctor') {
+            targetPermissions = _doctorPermissions;
+          } else if (role == 'staff' ||
+              role == 'nurse' ||
+              role == 'secretary') {
+            targetPermissions = _staffPermissions;
+          } else {
+            // Unknown role? Skip or give basic view?
+            // Let's skip to avoid over-granting.
+            continue;
+          }
+
+          bool changed = await _updateDocumentPermissions(
+              memberDoc.reference, data, targetPermissions);
+          if (changed) membersUpdated++;
+        }
+      }
+
+      _status =
+          'Migration Complete!\nUpdated $ownersUpdated Owners.\nUpdated $membersUpdated Clinic Members.';
+    } catch (e) {
+      _status = 'Error: $e';
+    } finally {
+      setState(() {
+        _isLoading = false;
+      });
+    }
+  }
+
+  Future<bool> _updateDocumentPermissions(DocumentReference ref,
+      Map<String, dynamic> data, List<String> permissionsToAdd) async {
+    List<dynamic> currentPermissions = data['permissions'] ?? [];
+    List<String> newPermissions = List.from(currentPermissions);
+    bool changed = false;
+
+    for (var perm in permissionsToAdd) {
+      if (!newPermissions.contains(perm)) {
+        newPermissions.add(perm);
+        changed = true;
+      }
+    }
+
+    if (changed) {
+      await ref.update({'permissions': newPermissions});
+    }
+    return changed;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(_status,
+              textAlign: TextAlign.center,
+              style: const TextStyle(fontSize: 16)),
+          const SizedBox(height: 20),
+          if (_isLoading)
+            const CircularProgressIndicator()
+          else
+            ElevatedButton(
+              onPressed: _runMigration,
+              child: const Text('Run Migration'),
+            ),
+          const SizedBox(height: 20),
+          const Padding(
+            padding: EdgeInsets.all(16.0),
+            child: Text(
+              'This tool will:\n1. Grant ALL permissions to Owners.\n2. Grant DOCTOR permissions to members with role "doctor".\n3. Grant STAFF permissions to members with role "staff/nurse/secretary".',
+              style: TextStyle(color: Colors.grey),
+              textAlign: TextAlign.center,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/core/app/app.dart
+++ b/lib/src/core/app/app.dart
@@ -140,7 +140,7 @@ class App extends StatelessWidget {
                         /// The title of the application displayed in the app bar or window.
                         ///
                         /// In this case, it is set to 'Dr Copilot'.
-                        title: 'Dr Copilot',
+                        title: 'Dr. Copilot',
 
                         /// Applies the current theme from the [themeNotifier] and allows for further customization
                         /// by creating a copy of the theme with additional modifications.

--- a/lib/src/core/app/notifiers/owner_notifier.dart
+++ b/lib/src/core/app/notifiers/owner_notifier.dart
@@ -3,6 +3,7 @@ import 'package:dr_copilot/src/features/auth/domain/models/clinic_model.dart';
 import 'package:dr_copilot/src/features/auth/domain/models/permission_enum.dart';
 import 'package:dr_copilot/src/features/auth/domain/models/role_enum.dart';
 import 'package:dr_copilot/src/features/auth/domain/repositories/auth_repository.dart';
+import 'package:dr_copilot/src/features/auth/domain/services/permission_service.dart';
 import 'package:flutter/foundation.dart';
 import 'package:get_it/get_it.dart';
 
@@ -20,25 +21,27 @@ class OwnerNotifier with ChangeNotifier {
   AppRole? _role;
   AppRole? get role => _role;
 
-  List<AppPermission> _permissions = [];
-  List<AppPermission> get permissions => _permissions;
-
   List<ClinicModel> _clinics = [];
   List<ClinicModel> get clinics => _clinics;
 
   bool _loading = false;
   bool get loading => _loading;
 
+  /// Delegate permission checks to PermissionService
   bool hasPermission(AppPermission permission) {
-    return _permissions.contains(permission);
+    return GetIt.I<PermissionService>().hasPermissionSync(
+      permission,
+      clinicId: _clinicId,
+    );
   }
 
   void clear() {
     _ownerId = null;
     _clinicId = null;
     _role = null;
-    _permissions = [];
     _clinics = [];
+    // Clear permission cache in service
+    GetIt.I<PermissionService>().clearCache();
     notifyListeners();
   }
 
@@ -50,14 +53,24 @@ class OwnerNotifier with ChangeNotifier {
     notifyListeners();
 
     try {
-      final user = await GetIt.I<AbstractAuthRepository>().getCurrentUser();
+      final userResult =
+          await GetIt.I<AbstractAuthRepository>().getCurrentUser();
+
+      final user = userResult.fold(
+        (failure) {
+          debugPrint(
+              '[OwnerNotifier] ❌ Error getting current user: ${failure.message}');
+          return null;
+        },
+        (user) => user,
+      );
+
       debugPrint('[OwnerNotifier] Current user: ${user?.uid}');
       if (user == null) {
         debugPrint('[OwnerNotifier] ❌ No user logged in.');
         _ownerId = null;
         _clinicId = null;
         _role = null;
-        _permissions = [];
         _loading = false;
         notifyListeners();
         return;
@@ -96,10 +109,10 @@ class OwnerNotifier with ChangeNotifier {
         debugPrint('[OwnerNotifier] No clinicId found.');
       }
 
-      // Load Role and Permissions from the clinic members subcollection (Single Source of Truth)
+      // Load Role from clinic members subcollection
       if (_clinicId != null) {
         debugPrint(
-          '[OwnerNotifier] Fetching permissions from clinics/$_clinicId/members/${user.uid}',
+          '[OwnerNotifier] Fetching role from clinics/$_clinicId/members/${user.uid}',
         );
         try {
           final memberDoc = await FirebaseFirestore.instance
@@ -122,36 +135,21 @@ class OwnerNotifier with ChangeNotifier {
               debugPrint('[OwnerNotifier] Loaded role: $_role');
             }
 
-            // Parse Permissions
-            if (memberData?['permissions'] != null) {
-              final permsList = memberData!['permissions'] as List<dynamic>;
-              _permissions = permsList.map((p) {
-                return AppPermission.values.firstWhere(
-                  (e) => e.name == p,
-                  orElse: () =>
-                      AppPermission.viewAllPatients, // Default fallback
-                );
-              }).toList();
-              debugPrint(
-                '[OwnerNotifier] Loaded ${_permissions.length} permissions',
-              );
-            } else {
-              _permissions = [];
-              debugPrint('[OwnerNotifier] No permissions field in member doc');
-            }
+            // Trigger PermissionService to cache permissions
+            debugPrint(
+                '[OwnerNotifier] Priming PermissionService permission cache');
+            await GetIt.I<PermissionService>().getUserPermissions(
+              clinicId: _clinicId,
+            );
           } else {
             debugPrint(
               '[OwnerNotifier] ❌ Member document not found for user in clinic $_clinicId',
             );
-            // Fallback or clear permissions?
-            // If member doc doesn't exist, they technically aren't a member or data is missing.
             _role = null;
-            _permissions = [];
           }
         } catch (e) {
-          debugPrint('[OwnerNotifier] ❌ Error fetching member permissions: $e');
+          debugPrint('[OwnerNotifier] ❌ Error fetching member data: $e');
           _role = null;
-          _permissions = [];
         }
       }
 
@@ -211,29 +209,9 @@ class OwnerNotifier with ChangeNotifier {
         }
       }
 
-      // 4. Fetch by ownerId (fallback/legacy)
-      if (_ownerId != null) {
-        debugPrint('[OwnerNotifier] Querying clinics for ownerId: $_ownerId');
-        try {
-          final clinicsSnap = await FirebaseFirestore.instance
-              .collection('clinics')
-              .where('ownerId', isEqualTo: _ownerId)
-              .get();
-
-          debugPrint(
-            '[OwnerNotifier] Found ${clinicsSnap.docs.length} clinics by ownerId',
-          );
-          for (var doc in clinicsSnap.docs) {
-            final clinicData = doc.data();
-            debugPrint(
-              '[OwnerNotifier]   - Clinic: ${doc.id} -> ${clinicData['name']}',
-            );
-            allClinics.add(ClinicModel.fromJson({'id': doc.id, ...clinicData}));
-          }
-        } catch (e) {
-          debugPrint('[OwnerNotifier] ❌ Error fetching clinics by ownerId: $e');
-        }
-      }
+      // NOTE: Removed ownerId query - security rules don't allow querying clinics by ownerId
+      // Clinics are already loaded from clinicIds/userClinics array above
+      // If we need owner-specific clinics, they should be in the user's clinicIds field
 
       // Deduplicate by ID
       final Map<String, ClinicModel> uniqueClinics = {
@@ -252,7 +230,6 @@ class OwnerNotifier with ChangeNotifier {
       debugPrint('[OwnerNotifier] ❌ Fatal error in loadOwnerIdAndClinicId: $e');
       // Set minimal defaults to allow app to continue
       _role = null;
-      _permissions = [];
       _clinics = [];
     } finally {
       _loading = false;

--- a/lib/src/core/error/error_handler.dart
+++ b/lib/src/core/error/error_handler.dart
@@ -1,0 +1,51 @@
+import 'package:dr_copilot/src/core/error/failures.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+
+class ErrorHandler {
+  static Failure mapExceptionToFailure(Object error) {
+    debugPrint('ErrorHandler caught error: $error');
+
+    if (error is FirebaseAuthException) {
+      return _handleFirebaseAuthException(error);
+    } else if (error is FirebaseException) {
+      return ServerFailure(error.message ?? 'Server error occurred',
+          int.tryParse(error.code) ?? 500);
+    } else if (error is SocketException) {
+      return NetworkFailure('errors.network', 0); // Use localization key
+    } else if (error is FormatException) {
+      return ValidationFailure('errors.format', 400);
+    } else if (error is TypeError) {
+      return ValidationFailure('errors.type_error', 400);
+    } else {
+      return UnknownFailure('errors.unknown');
+    }
+  }
+
+  static Failure _handleFirebaseAuthException(FirebaseAuthException error) {
+    switch (error.code) {
+      case 'user-not-found':
+        return AuthFailure('errors.auth.user_not_found');
+      case 'wrong-password':
+        return AuthFailure('errors.auth.wrong_password');
+      case 'email-already-in-use':
+        return AuthFailure('errors.auth.email_already_in_use');
+      case 'invalid-email':
+        return AuthFailure('errors.auth.invalid_email');
+      case 'user-disabled':
+        return AuthFailure('errors.auth.user_disabled');
+      case 'operation-not-allowed':
+        return AuthFailure('errors.auth.operation_not_allowed');
+      case 'weak-password':
+        return AuthFailure('errors.auth.weak_password');
+      case 'invalid-credential':
+        return AuthFailure('errors.auth.invalid_credential');
+      case 'network-request-failed':
+        return NetworkFailure('errors.network', 0);
+      default:
+        return AuthFailure(error.message ?? 'errors.auth.default');
+    }
+  }
+}

--- a/lib/src/core/error/failures.dart
+++ b/lib/src/core/error/failures.dart
@@ -73,3 +73,14 @@ class ApiKeyFailure extends Failure {
   ApiKeyFailure(super.message, [super.code = 401]);
 }
 
+/// Represents a failure that occurs during authentication processes.
+class AuthFailure extends Failure {
+  /// Represents a failure related to authentication (e.g. wrong password, user not found).
+  AuthFailure(super.message, [super.code = 401]);
+}
+
+/// Represents an unknown or unexpected failure.
+class UnknownFailure extends Failure {
+  /// Represents a failure that hasn't been specifically categorized.
+  UnknownFailure(super.message, [super.code = 500]);
+}

--- a/lib/src/core/injections.dart
+++ b/lib/src/core/injections.dart
@@ -4,6 +4,7 @@ import 'package:dr_copilot/src/features/subscription/domain/services/quota_servi
 import 'package:dr_copilot/src/features/subscription/domain/services/subscription_service.dart';
 import 'package:dr_copilot/src/features/auth/auth_injections.dart';
 import 'package:dr_copilot/src/core/services/services_injections.dart';
+import 'package:dr_copilot/src/core/services/remote_config_service.dart';
 import 'package:dr_copilot/src/features/calendar/calendar_injections.dart';
 import 'package:dr_copilot/src/features/calendar_events/calendar_events_injections.dart';
 import 'package:dr_copilot/src/features/copilot_chat/copilot_injections.dart';
@@ -59,6 +60,7 @@ Future<void> initInjections() async {
   sl.registerLazySingleton<NetworkInfo>(() => NetworkInfoImpl(sl()));
   sl.registerLazySingleton(() => const FlutterSecureStorage());
   sl.registerLazySingleton(() => BiometricAuthService());
+  sl.registerLazySingleton(() => RemoteConfigService());
   initServicesInjections();
 
   // Features (order matters due to dependencies)
@@ -174,7 +176,11 @@ Future<void> initInjections() async {
 
   // Recycle Bin
   sl.registerFactory(
-    () => RecycleBinBloc(evaluationsRepository: sl(), sessionsRepository: sl()),
+    () => RecycleBinBloc(
+      evaluationsRepository: sl(),
+      sessionsRepository: sl(),
+      patientsRepository: sl(),
+      calendarEventsRepository: sl(),
+    ),
   );
 }
-

--- a/lib/src/core/router/routing_config.dart
+++ b/lib/src/core/router/routing_config.dart
@@ -59,6 +59,8 @@ import 'package:go_router/go_router.dart';
 import 'package:dr_copilot/src/core/injections.dart';
 import 'package:dr_copilot/src/features/auth/domain/usecases/login_usecase.dart';
 import 'package:dr_copilot/src/features/auth/domain/models/user_model.dart';
+import 'package:dartz/dartz.dart';
+import 'package:dr_copilot/src/core/error/failures.dart';
 
 class RoutingConfig {
   static final GlobalKey<ScaffoldMessengerState> scaffoldMessengerKey =
@@ -344,7 +346,7 @@ class RoutingConfig {
             path: '/invitations',
             name: 'invitations',
             builder: (context, state) {
-              return FutureBuilder<UserModel?>(
+              return FutureBuilder<Either<Failure, UserModel?>>(
                 future: sl<AuthUseCase>().getCurrentUser(),
                 builder: (context, snapshot) {
                   if (snapshot.connectionState == ConnectionState.waiting) {
@@ -352,7 +354,40 @@ class RoutingConfig {
                       body: Center(child: CircularProgressIndicator()),
                     );
                   }
-                  final clinicId = snapshot.data?.primaryClinicId ?? '';
+
+                  final user =
+                      snapshot.data?.fold((failure) => null, (user) => user);
+
+                  final clinicId = user?.primaryClinicId;
+                  if (clinicId == null || clinicId.isEmpty) {
+                    return Scaffold(
+                      appBar: AppBar(title: Text('invitations'.tr())),
+                      body: Center(
+                        child: Padding(
+                          padding: const EdgeInsets.all(24.0),
+                          child: Column(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              const Icon(Icons.warning_amber_rounded,
+                                  size: 80, color: Colors.orange),
+                              const SizedBox(height: 24),
+                              Text(
+                                'No clinic assigned',
+                                style: Theme.of(context).textTheme.titleLarge,
+                                textAlign: TextAlign.center,
+                              ),
+                              const SizedBox(height: 12),
+                              Text(
+                                'You need to be assigned to a clinic to view invitations. Please contact your administrator.',
+                                style: Theme.of(context).textTheme.bodyMedium,
+                                textAlign: TextAlign.center,
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    );
+                  }
                   return InvitationsPage(clinicId: clinicId);
                 },
               );

--- a/lib/src/core/services/remote_config_service.dart
+++ b/lib/src/core/services/remote_config_service.dart
@@ -1,0 +1,33 @@
+import 'package:firebase_remote_config/firebase_remote_config.dart';
+import 'package:flutter/foundation.dart';
+
+class RemoteConfigService {
+  final FirebaseRemoteConfig _remoteConfig;
+
+  RemoteConfigService({FirebaseRemoteConfig? remoteConfig})
+      : _remoteConfig = remoteConfig ?? FirebaseRemoteConfig.instance;
+
+  Future<void> initialize() async {
+    try {
+      await _remoteConfig.setConfigSettings(RemoteConfigSettings(
+        fetchTimeout: const Duration(minutes: 1),
+        minimumFetchInterval:
+            const Duration(hours: 1), // Use lower interval for dev
+      ));
+
+      await _remoteConfig.setDefaults(const {
+        'signup_enabled': true,
+        'max_allowed_users': 1000,
+      });
+
+      await _remoteConfig.fetchAndActivate();
+      debugPrint('Remote Config initialized. signup_enabled: $isSignupEnabled');
+    } catch (e) {
+      debugPrint('Error initializing Remote Config: $e');
+    }
+  }
+
+  bool get isSignupEnabled => _remoteConfig.getBool('signup_enabled');
+
+  int get maxAllowedUsers => _remoteConfig.getInt('max_allowed_users');
+}

--- a/lib/src/features/appointments/evaluations/data/remote/evaluation_firebase_api.dart
+++ b/lib/src/features/appointments/evaluations/data/remote/evaluation_firebase_api.dart
@@ -32,6 +32,9 @@ class EvaluationsFirebaseApi extends AbstractEvaluationsRepository {
   }) async {
     try {
       final user = FirebaseAuth.instance.currentUser;
+      if (clinicId == null) {
+        return Left(ServerFailure('No clinic ID found', 403));
+      }
       if (user != null) {
         Query queryRef = _evaluationsCollection.where(
           'clinicId',
@@ -99,6 +102,9 @@ class EvaluationsFirebaseApi extends AbstractEvaluationsRepository {
   ) async {
     try {
       final user = FirebaseAuth.instance.currentUser;
+      if (clinicId == null) {
+        return Left(ServerFailure('No clinic ID found', 403));
+      }
       if (user != null) {
         final data = evaluationModel.toJson();
 
@@ -115,6 +121,7 @@ class EvaluationsFirebaseApi extends AbstractEvaluationsRepository {
           ...data,
           'createdBy': user.uid,
           'doctorId': user.uid, // Ensure doctorId is set
+          'clinicId': clinicId, // Ensure clinicId is set
         });
         final createdEvaluation = evaluationModel.copyWith(
           id: docRef.id, // Assign the generated document ID
@@ -247,6 +254,9 @@ class EvaluationsFirebaseApi extends AbstractEvaluationsRepository {
   Future<Either<Failure, List<EvaluationModel>>> getDeletedEvaluations() async {
     try {
       final user = FirebaseAuth.instance.currentUser;
+      if (clinicId == null) {
+        return Left(ServerFailure('No clinic ID found', 403));
+      }
       if (user != null) {
         Query queryRef = _evaluationsCollection.where(
           'clinicId',
@@ -330,6 +340,9 @@ class EvaluationsFirebaseApi extends AbstractEvaluationsRepository {
     }
     try {
       final user = FirebaseAuth.instance.currentUser;
+      if (clinicId == null) {
+        return Left(ServerFailure('No clinic ID found', 403));
+      }
       if (user != null) {
         List<String> patientIds = [];
         if (name != null && name.isNotEmpty) {
@@ -430,6 +443,9 @@ class EvaluationsFirebaseApi extends AbstractEvaluationsRepository {
     }
     try {
       final user = FirebaseAuth.instance.currentUser;
+      if (clinicId == null) {
+        return Left(ServerFailure('No clinic ID found', 403));
+      }
       if (user != null) {
         debugPrint(
           'Filtering evaluations for user: ${user.uid} on date: $date',
@@ -531,6 +547,9 @@ class EvaluationsFirebaseApi extends AbstractEvaluationsRepository {
   Future<Either<Failure, List<EvaluationModel>>> getAllEvaluations() async {
     try {
       final user = FirebaseAuth.instance.currentUser;
+      if (clinicId == null) {
+        return Left(ServerFailure('No clinic ID found', 403));
+      }
       if (user != null) {
         Query queryRef = _evaluationsCollection.where(
           'clinicId',
@@ -614,6 +633,9 @@ class EvaluationsFirebaseApi extends AbstractEvaluationsRepository {
   Future<Either<Failure, int>> getEvaluationsCount() async {
     try {
       final user = FirebaseAuth.instance.currentUser;
+      if (clinicId == null) {
+        return Left(ServerFailure('No clinic ID found', 403));
+      }
       if (user != null) {
         Query query = _evaluationsCollection.where(
           'clinicId',
@@ -649,6 +671,9 @@ class EvaluationsFirebaseApi extends AbstractEvaluationsRepository {
     }
     try {
       final user = FirebaseAuth.instance.currentUser;
+      if (clinicId == null) {
+        return Left(ServerFailure('No clinic ID found', 403));
+      }
       if (user != null) {
         final start = DateTime(year, month, 1);
         final end = (month < 12)
@@ -694,6 +719,9 @@ class EvaluationsFirebaseApi extends AbstractEvaluationsRepository {
     }
     try {
       final user = FirebaseAuth.instance.currentUser;
+      if (clinicId == null) {
+        return Left(ServerFailure('No clinic ID found', 403));
+      }
       if (user != null) {
         final start = DateTime(year, 1, 1);
         final end = DateTime(year + 1, 1, 1);
@@ -738,6 +766,9 @@ class EvaluationsFirebaseApi extends AbstractEvaluationsRepository {
     }
     try {
       final user = FirebaseAuth.instance.currentUser;
+      if (clinicId == null) {
+        return Left(ServerFailure('No clinic ID found', 403));
+      }
       if (user != null) {
         final start = DateTime(year, month, 1);
         final end = (month < 12)
@@ -787,6 +818,9 @@ class EvaluationsFirebaseApi extends AbstractEvaluationsRepository {
     }
     try {
       final user = FirebaseAuth.instance.currentUser;
+      if (clinicId == null) {
+        return Left(ServerFailure('No clinic ID found', 403));
+      }
       if (user != null) {
         final start = DateTime(year, 1, 1);
         final end = DateTime(year + 1, 1, 1);

--- a/lib/src/features/appointments/evaluations/domain/models/evaluation_model.g.dart
+++ b/lib/src/features/appointments/evaluations/domain/models/evaluation_model.g.dart
@@ -25,23 +25,24 @@ EvaluationModel _$EvaluationModelFromJson(Map<String, dynamic> json) =>
       doctorId: json['doctorId'] as String?,
     );
 
-Map<String, dynamic> _$EvaluationModelToJson(
-  EvaluationModel instance,
-) => <String, dynamic>{
-  'id': instance.id,
-  'patientId': instance.patientId,
-  'patientName': instance.patientName,
-  'price': instance.price,
-  'startDateTime': const TimestampConverter().toJson(instance.startDateTime),
-  'endDateTime': const TimestampConverter().toJson(instance.endDateTime),
-  'ownerId': instance.ownerId,
-  'clinicId': instance.clinicId,
-  'createdBy': instance.createdBy,
-  'updatedBy': instance.updatedBy,
-  'deletedBy': instance.deletedBy,
-  'createdAt': const TimestampConverter().toJson(instance.createdAt),
-  'updatedAt': const NullableTimestampConverter().toJson(instance.updatedAt),
-  'deletedAt': const NullableTimestampConverter().toJson(instance.deletedAt),
-  'doctorId': instance.doctorId,
-};
-
+Map<String, dynamic> _$EvaluationModelToJson(EvaluationModel instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'patientId': instance.patientId,
+      'patientName': instance.patientName,
+      'price': instance.price,
+      'startDateTime':
+          const TimestampConverter().toJson(instance.startDateTime),
+      'endDateTime': const TimestampConverter().toJson(instance.endDateTime),
+      'ownerId': instance.ownerId,
+      'clinicId': instance.clinicId,
+      'createdBy': instance.createdBy,
+      'updatedBy': instance.updatedBy,
+      'deletedBy': instance.deletedBy,
+      'createdAt': const TimestampConverter().toJson(instance.createdAt),
+      'updatedAt':
+          const NullableTimestampConverter().toJson(instance.updatedAt),
+      'deletedAt':
+          const NullableTimestampConverter().toJson(instance.deletedAt),
+      'doctorId': instance.doctorId,
+    };

--- a/lib/src/features/appointments/evaluations/presentation/pages/evaluations_page.dart
+++ b/lib/src/features/appointments/evaluations/presentation/pages/evaluations_page.dart
@@ -58,11 +58,11 @@ class _EvaluationsPageState extends State<EvaluationsPage> {
         if (_canLoadMore) {
           _canLoadMore = false;
           context.read<EvaluationsBloc>().add(
-            LoadMoreEvaluations(
-              lastDocumentId: state.evaluations.last.id,
-              limit: 20,
-            ),
-          );
+                LoadMoreEvaluations(
+                  lastDocumentId: state.evaluations.last.id,
+                  limit: 20,
+                ),
+              );
           Future.delayed(const Duration(seconds: 1), () {
             _canLoadMore = true;
           });
@@ -107,8 +107,8 @@ class _EvaluationsPageState extends State<EvaluationsPage> {
                         _selectedIndex = 0; // Reset selection on new query
                       });
                       context.read<EvaluationsBloc>().add(
-                        SearchEvaluations(name: query),
-                      ); // Trigger search event
+                            SearchEvaluations(name: query),
+                          ); // Trigger search event
                     },
                     onSubmitted: (_) {
                       _listFocusNode.requestFocus();
@@ -156,7 +156,7 @@ class _EvaluationsPageState extends State<EvaluationsPage> {
               child: Row(
                 children: [
                   IconButton(
-                    icon: const Icon(Icons.filter_alt),
+                    icon: const Icon(Icons.filter_alt_outlined),
                     tooltip: 'toggleFilters'.tr(),
                     onPressed: () {
                       setState(() {
@@ -193,8 +193,8 @@ class _EvaluationsPageState extends State<EvaluationsPage> {
                           if (!context.mounted) return;
 
                           context.read<EvaluationsBloc>().add(
-                            GetEvaluationsByDate(date: selectedDate),
-                          );
+                                GetEvaluationsByDate(date: selectedDate),
+                              );
                         }
                       },
                     ),
@@ -239,8 +239,8 @@ class _EvaluationsPageState extends State<EvaluationsPage> {
               final evaluations = (state is EvaluationsLoaded)
                   ? state.evaluations
                   : (state is EvaluationsLoadingMore)
-                  ? state.evaluations
-                  : <EvaluationModel>[];
+                      ? state.evaluations
+                      : <EvaluationModel>[];
 
               final groupedEvaluations = <String, List<EvaluationModel>>{};
               for (var evaluation in evaluations) {
@@ -253,9 +253,9 @@ class _EvaluationsPageState extends State<EvaluationsPage> {
                     .add(evaluation);
               }
 
-              final sortedGroupedEvaluations =
-                  groupedEvaluations.entries.toList()
-                    ..sort((a, b) => b.key.compareTo(a.key));
+              final sortedGroupedEvaluations = groupedEvaluations.entries
+                  .toList()
+                ..sort((a, b) => b.key.compareTo(a.key));
 
               return Column(
                 children: [
@@ -267,15 +267,16 @@ class _EvaluationsPageState extends State<EvaluationsPage> {
                     child: Row(
                       mainAxisAlignment: MainAxisAlignment.start,
                       children: [
-                        Icon(Icons.assignment, size: 20, color: Colors.blue),
+                        Icon(Icons.assignment_outlined,
+                            size: 20, color: Colors.blue),
                         const SizedBox(width: 4),
                         Text(
                           '${evaluations.length} ',
-                          style: Theme.of(context).textTheme.bodyLarge
-                              ?.copyWith(
-                                fontWeight: FontWeight.bold,
-                                color: Colors.blue,
-                              ),
+                          style:
+                              Theme.of(context).textTheme.bodyLarge?.copyWith(
+                                    fontWeight: FontWeight.bold,
+                                    color: Colors.blue,
+                                  ),
                         ),
                         Text(
                           'loaded'.tr(),
@@ -286,14 +287,16 @@ class _EvaluationsPageState extends State<EvaluationsPage> {
                             children: [
                               const SizedBox(width: 16),
                               Icon(
-                                Icons.cloud,
+                                Icons.cloud_outlined,
                                 size: 18,
                                 color: Colors.deepPurple,
                               ),
                               const SizedBox(width: 2),
                               Text(
                                 '$_firestoreEvaluationsCount',
-                                style: Theme.of(context).textTheme.bodyMedium
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .bodyMedium
                                     ?.copyWith(
                                       fontWeight: FontWeight.bold,
                                       color: Colors.deepPurple,
@@ -436,4 +439,3 @@ class _EvaluationsPageState extends State<EvaluationsPage> {
     }
   }
 }
-

--- a/lib/src/features/appointments/sessions/data/remote/session_firebase_api.dart
+++ b/lib/src/features/appointments/sessions/data/remote/session_firebase_api.dart
@@ -16,12 +16,12 @@ class SessionsFirebaseApi extends AbstractSessionsRepository {
   String? get clinicId => OwnerNotifier().clinicId;
 
   /// Reference to the Firestore collection for sessions.
-  final CollectionReference _sessionsCollection = FirebaseFirestore.instance
-      .collection('sessions');
+  final CollectionReference _sessionsCollection =
+      FirebaseFirestore.instance.collection('sessions');
 
   /// Reference to the Firestore collection for patients.
-  final CollectionReference _patientsCollection = FirebaseFirestore.instance
-      .collection('patients');
+  final CollectionReference _patientsCollection =
+      FirebaseFirestore.instance.collection('patients');
 
   /// Firebase Authentication instance for user authentication.
   final FirebaseAuth _auth = FirebaseAuth.instance;
@@ -47,6 +47,9 @@ class SessionsFirebaseApi extends AbstractSessionsRepository {
   }) async {
     try {
       final user = FirebaseAuth.instance.currentUser;
+      if (clinicId == null) {
+        return Left(ServerFailure('No clinic ID found', 403));
+      }
       if (user != null) {
         Query queryRef = _sessionsCollection.where(
           'clinicId',
@@ -62,9 +65,8 @@ class SessionsFirebaseApi extends AbstractSessionsRepository {
         queryRef = queryRef.where('deletedAt', isNull: true);
 
         if (lastDocumentID != null) {
-          final lastDocumentSnapshot = await _sessionsCollection
-              .doc(lastDocumentID)
-              .get();
+          final lastDocumentSnapshot =
+              await _sessionsCollection.doc(lastDocumentID).get();
           if (lastDocumentSnapshot.exists) {
             queryRef = queryRef
                 .orderBy('startDateTime', descending: true)
@@ -74,9 +76,8 @@ class SessionsFirebaseApi extends AbstractSessionsRepository {
             throw Exception('Document with ID $lastDocumentID does not exist');
           }
         } else {
-          queryRef = queryRef
-              .orderBy('startDateTime', descending: true)
-              .limit(limit);
+          queryRef =
+              queryRef.orderBy('startDateTime', descending: true).limit(limit);
         }
 
         final snapshot = await queryRef.get();
@@ -129,6 +130,9 @@ class SessionsFirebaseApi extends AbstractSessionsRepository {
     try {
       final user = _auth.currentUser;
       if (user != null) {
+        if (clinicId == null) {
+          return Left(ServerFailure('No clinic ID found', 403));
+        }
         // Prepare the session data for Firestore
         final data = sessionModel.toJson();
 
@@ -146,6 +150,7 @@ class SessionsFirebaseApi extends AbstractSessionsRepository {
           ...data,
           'createdBy': user.uid,
           'doctorId': user.uid, // Ensure doctorId is set
+          'clinicId': clinicId,
         });
 
         // Create a new SessionModel with the generated document ID and patientName
@@ -301,6 +306,9 @@ class SessionsFirebaseApi extends AbstractSessionsRepository {
   Future<Either<Failure, List<SessionModel>>> getDeletedSessions() async {
     try {
       final user = FirebaseAuth.instance.currentUser;
+      if (clinicId == null) {
+        return Left(ServerFailure('No clinic ID found', 403));
+      }
       if (user != null) {
         Query queryRef = _sessionsCollection.where(
           'clinicId',
@@ -391,6 +399,9 @@ class SessionsFirebaseApi extends AbstractSessionsRepository {
     }
     try {
       final user = FirebaseAuth.instance.currentUser;
+      if (clinicId == null) {
+        return Left(ServerFailure('No clinic ID found', 403));
+      }
       if (user != null) {
         List<String> patientIds = [];
         if (name != null && name.isNotEmpty) {
@@ -428,9 +439,8 @@ class SessionsFirebaseApi extends AbstractSessionsRepository {
         }
 
         if (lastDocumentID != null) {
-          final lastDocumentSnapshot = await _sessionsCollection
-              .doc(lastDocumentID)
-              .get();
+          final lastDocumentSnapshot =
+              await _sessionsCollection.doc(lastDocumentID).get();
           if (lastDocumentSnapshot.exists) {
             queryRef = queryRef.startAfterDocument(lastDocumentSnapshot);
           } else {
@@ -499,6 +509,9 @@ class SessionsFirebaseApi extends AbstractSessionsRepository {
     }
     try {
       final user = _auth.currentUser;
+      if (clinicId == null) {
+        return Left(ServerFailure('No clinic ID found', 403));
+      }
       if (user != null) {
         debugPrint('Filtering sessions for user: ${user.uid} on date: $date');
         Query queryRef = _sessionsCollection.where(
@@ -589,9 +602,8 @@ class SessionsFirebaseApi extends AbstractSessionsRepository {
           debugPrint('Error: Document data is null');
           return Left(ServerFailure('Document data is null', 400));
         }
-        final sessionTypeString =
-            data['sessionType']
-                as String?; // Changed from 'type' to 'sessionType' based on model
+        final sessionTypeString = data['sessionType']
+            as String?; // Changed from 'type' to 'sessionType' based on model
 
         if (sessionTypeString != null) {
           return Right(sessionTypeString);
@@ -679,6 +691,9 @@ class SessionsFirebaseApi extends AbstractSessionsRepository {
   Future<Either<Failure, List<SessionModel>>> getAllSessions() async {
     try {
       final user = FirebaseAuth.instance.currentUser;
+      if (clinicId == null) {
+        return Left(ServerFailure('No clinic ID found', 403));
+      }
       if (user != null) {
         Query queryRef = _sessionsCollection.where(
           'clinicId',
@@ -693,9 +708,8 @@ class SessionsFirebaseApi extends AbstractSessionsRepository {
         // Filter out deleted sessions
         queryRef = queryRef.where('deletedAt', isNull: true);
 
-        final snapshot = await queryRef
-            .orderBy('startDateTime', descending: true)
-            .get();
+        final snapshot =
+            await queryRef.orderBy('startDateTime', descending: true).get();
 
         List<SessionModel> sessions = await Future.wait(
           snapshot.docs.map((doc) async {
@@ -734,6 +748,9 @@ class SessionsFirebaseApi extends AbstractSessionsRepository {
     }
     try {
       final user = _auth.currentUser;
+      if (clinicId == null) {
+        return Left(ServerFailure('No clinic ID found', 403));
+      }
       if (user != null) {
         Query query = _sessionsCollection.where(
           'clinicId',
@@ -770,6 +787,9 @@ class SessionsFirebaseApi extends AbstractSessionsRepository {
     }
     try {
       final user = _auth.currentUser;
+      if (clinicId == null) {
+        return Left(ServerFailure('No clinic ID found', 403));
+      }
       if (user != null) {
         final start = DateTime(year, month, 1);
         final end = (month < 12)
@@ -887,9 +907,8 @@ class SessionsFirebaseApi extends AbstractSessionsRepository {
               isGreaterThanOrEqualTo: Timestamp.fromDate(start),
             )
             .where('startDateTime', isLessThan: Timestamp.fromDate(end));
-        final aggregateQuerySnapshot = await query
-            .aggregate(sum('price'))
-            .get();
+        final aggregateQuerySnapshot =
+            await query.aggregate(sum('price')).get();
         final endSum = aggregateQuerySnapshot.getSum('price') ?? 0;
         return Right(
           endSum is int ? endSum.toDouble() : (endSum as double? ?? 0.0),
@@ -938,9 +957,8 @@ class SessionsFirebaseApi extends AbstractSessionsRepository {
               isGreaterThanOrEqualTo: Timestamp.fromDate(start),
             )
             .where('startDateTime', isLessThan: Timestamp.fromDate(end));
-        final aggregateQuerySnapshot = await query
-            .aggregate(sum('price'))
-            .get();
+        final aggregateQuerySnapshot =
+            await query.aggregate(sum('price')).get();
         final endSum = aggregateQuerySnapshot.getSum('price') ?? 0;
         return Right(
           endSum is int ? endSum.toDouble() : (endSum as double? ?? 0.0),
@@ -977,9 +995,8 @@ class SessionsFirebaseApi extends AbstractSessionsRepository {
         // Filter out deleted sessions
         query = query.where('deletedAt', isNull: true);
 
-        final aggregateQuerySnapshot = await query
-            .aggregate(sum('price'))
-            .get();
+        final aggregateQuerySnapshot =
+            await query.aggregate(sum('price')).get();
         final endSum = aggregateQuerySnapshot.getSum('price') ?? 0;
         return Right(
           endSum is int ? endSum.toDouble() : (endSum as double? ?? 0.0),
@@ -992,4 +1009,3 @@ class SessionsFirebaseApi extends AbstractSessionsRepository {
     }
   }
 }
-

--- a/lib/src/features/appointments/sessions/domain/models/session_model.g.dart
+++ b/lib/src/features/appointments/sessions/domain/models/session_model.g.dart
@@ -7,42 +7,43 @@ part of 'session_model.dart';
 // **************************************************************************
 
 SessionModel _$SessionModelFromJson(Map<String, dynamic> json) => SessionModel(
-  id: json['id'] as String,
-  patientId: json['patientId'] as String,
-  price: (json['price'] as num).toDouble(),
-  startDateTime: const TimestampConverter().fromJson(json['startDateTime']),
-  endDateTime: const TimestampConverter().fromJson(json['endDateTime']),
-  sessionType: json['sessionType'] as String?,
-  ownerId: json['ownerId'] as String,
-  clinicId: json['clinicId'] as String,
-  createdBy: json['createdBy'] as String,
-  patientName: json['patientName'] as String?,
-  updatedBy: json['updatedBy'] as String?,
-  deletedBy: json['deletedBy'] as String?,
-  deletedAt: const NullableTimestampConverter().fromJson(json['deletedAt']),
-  createdAt: const TimestampConverter().fromJson(json['createdAt']),
-  updatedAt: const NullableTimestampConverter().fromJson(json['updatedAt']),
-  doctorId: json['doctorId'] as String?,
-);
+      id: json['id'] as String,
+      patientId: json['patientId'] as String,
+      price: (json['price'] as num).toDouble(),
+      startDateTime: const TimestampConverter().fromJson(json['startDateTime']),
+      endDateTime: const TimestampConverter().fromJson(json['endDateTime']),
+      sessionType: json['sessionType'] as String?,
+      ownerId: json['ownerId'] as String,
+      clinicId: json['clinicId'] as String,
+      createdBy: json['createdBy'] as String,
+      patientName: json['patientName'] as String?,
+      updatedBy: json['updatedBy'] as String?,
+      deletedBy: json['deletedBy'] as String?,
+      deletedAt: const NullableTimestampConverter().fromJson(json['deletedAt']),
+      createdAt: const TimestampConverter().fromJson(json['createdAt']),
+      updatedAt: const NullableTimestampConverter().fromJson(json['updatedAt']),
+      doctorId: json['doctorId'] as String?,
+    );
 
-Map<String, dynamic> _$SessionModelToJson(
-  SessionModel instance,
-) => <String, dynamic>{
-  'id': instance.id,
-  'patientId': instance.patientId,
-  'price': instance.price,
-  'startDateTime': const TimestampConverter().toJson(instance.startDateTime),
-  'endDateTime': const TimestampConverter().toJson(instance.endDateTime),
-  'sessionType': instance.sessionType,
-  'ownerId': instance.ownerId,
-  'clinicId': instance.clinicId,
-  'createdBy': instance.createdBy,
-  'patientName': instance.patientName,
-  'updatedBy': instance.updatedBy,
-  'deletedBy': instance.deletedBy,
-  'deletedAt': const NullableTimestampConverter().toJson(instance.deletedAt),
-  'createdAt': const TimestampConverter().toJson(instance.createdAt),
-  'updatedAt': const NullableTimestampConverter().toJson(instance.updatedAt),
-  'doctorId': instance.doctorId,
-};
-
+Map<String, dynamic> _$SessionModelToJson(SessionModel instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'patientId': instance.patientId,
+      'price': instance.price,
+      'startDateTime':
+          const TimestampConverter().toJson(instance.startDateTime),
+      'endDateTime': const TimestampConverter().toJson(instance.endDateTime),
+      'sessionType': instance.sessionType,
+      'ownerId': instance.ownerId,
+      'clinicId': instance.clinicId,
+      'createdBy': instance.createdBy,
+      'patientName': instance.patientName,
+      'updatedBy': instance.updatedBy,
+      'deletedBy': instance.deletedBy,
+      'deletedAt':
+          const NullableTimestampConverter().toJson(instance.deletedAt),
+      'createdAt': const TimestampConverter().toJson(instance.createdAt),
+      'updatedAt':
+          const NullableTimestampConverter().toJson(instance.updatedAt),
+      'doctorId': instance.doctorId,
+    };

--- a/lib/src/features/appointments/sessions/presentation/pages/sessions_page.dart
+++ b/lib/src/features/appointments/sessions/presentation/pages/sessions_page.dart
@@ -62,8 +62,9 @@ class _SessionsPageState extends State<SessionsPage> {
         if (_canLoadMore) {
           _canLoadMore = false;
           context.read<SessionsBloc>().add(
-            LoadMoreSessions(lastDocumentId: state.sessions.last.id, limit: 20),
-          );
+                LoadMoreSessions(
+                    lastDocumentId: state.sessions.last.id, limit: 20),
+              );
           Future.delayed(const Duration(seconds: 1), () {
             _canLoadMore = true;
           });
@@ -108,8 +109,8 @@ class _SessionsPageState extends State<SessionsPage> {
                         _selectedIndex = 0; // Reset selection on new query
                       });
                       context.read<SessionsBloc>().add(
-                        SearchSessions(name: query),
-                      ); // Trigger search event
+                            SearchSessions(name: query),
+                          ); // Trigger search event
                     },
                     onSubmitted: (_) {
                       _listFocusNode.requestFocus();
@@ -157,7 +158,7 @@ class _SessionsPageState extends State<SessionsPage> {
               child: Row(
                 children: [
                   IconButton(
-                    icon: const Icon(Icons.filter_alt),
+                    icon: const Icon(Icons.filter_alt_outlined),
                     tooltip: 'toggleFilters'.tr(),
                     onPressed: () {
                       setState(() {
@@ -194,8 +195,8 @@ class _SessionsPageState extends State<SessionsPage> {
                           if (!context.mounted) return;
 
                           context.read<SessionsBloc>().add(
-                            GetSessionsByDate(date: selectedDate),
-                          );
+                                GetSessionsByDate(date: selectedDate),
+                              );
                         }
                       },
                     ),
@@ -254,8 +255,8 @@ class _SessionsPageState extends State<SessionsPage> {
               final sessions = (state is SessionsLoaded)
                   ? state.sessions
                   : (state is SessionsLoadingMore)
-                  ? state.sessions
-                  : <SessionModel>[];
+                      ? state.sessions
+                      : <SessionModel>[];
 
               final groupedSessions = <String, List<SessionModel>>{};
               for (var session in sessions) {
@@ -283,15 +284,16 @@ class _SessionsPageState extends State<SessionsPage> {
                     child: Row(
                       mainAxisAlignment: MainAxisAlignment.start,
                       children: [
-                        Icon(Icons.assignment, size: 20, color: Colors.blue),
+                        Icon(Icons.assignment_outlined,
+                            size: 20, color: Colors.blue),
                         const SizedBox(width: 4),
                         Text(
                           '${sessions.length} ',
-                          style: Theme.of(context).textTheme.bodyLarge
-                              ?.copyWith(
-                                fontWeight: FontWeight.bold,
-                                color: Colors.blue,
-                              ),
+                          style:
+                              Theme.of(context).textTheme.bodyLarge?.copyWith(
+                                    fontWeight: FontWeight.bold,
+                                    color: Colors.blue,
+                                  ),
                         ),
                         Text(
                           'loaded'.tr(),
@@ -299,11 +301,14 @@ class _SessionsPageState extends State<SessionsPage> {
                         ),
                         if (_firestoreSessionsCount != null) ...[
                           const SizedBox(width: 16),
-                          Icon(Icons.cloud, size: 18, color: Colors.deepPurple),
+                          Icon(Icons.cloud_outlined,
+                              size: 18, color: Colors.deepPurple),
                           const SizedBox(width: 2),
                           Text(
                             '$_firestoreSessionsCount',
-                            style: Theme.of(context).textTheme.bodyMedium
+                            style: Theme.of(context)
+                                .textTheme
+                                .bodyMedium
                                 ?.copyWith(
                                   fontWeight: FontWeight.bold,
                                   color: Colors.deepPurple,
@@ -446,4 +451,3 @@ class _SessionsPageState extends State<SessionsPage> {
     ).format(parsedDate ?? DateTime.now());
   }
 }
-

--- a/lib/src/features/auth/data/remote/auth_firebase_api.dart
+++ b/lib/src/features/auth/data/remote/auth_firebase_api.dart
@@ -3,15 +3,16 @@ import 'package:dr_copilot/src/features/auth/domain/models/role_enum.dart';
 import 'package:dr_copilot/src/features/auth/domain/models/role_defaults.dart';
 import 'package:dr_copilot/src/features/auth/domain/models/user_model.dart';
 
-import 'package:dr_copilot/src/features/auth/domain/repositories/auth_repository.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:dr_copilot/src/core/helper/google_signin_helper.dart';
 import 'package:flutter/foundation.dart';
 import 'package:universal_io/io.dart' as io;
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:dr_copilot/src/core/services/error_reporting_service.dart';
+import 'package:dr_copilot/src/core/injections.dart';
+import 'package:dr_copilot/src/core/services/remote_config_service.dart';
 
-class AuthFirebaseApi extends AbstractAuthRepository {
+class AuthFirebaseApi {
   /// An instance of [FirebaseAuth] used to handle authentication operations
   /// such as sign-in, sign-up, and sign-out with Firebase in the application.
   final FirebaseAuth _firebaseAuth;
@@ -99,7 +100,6 @@ class AuthFirebaseApi extends AbstractAuthRepository {
   /// Returns a [UserModel] representing the authenticated user upon successful login.
   ///
   /// Throws an exception if authentication fails.
-  @override
   Future<UserModel?> signInWithEmailAndPassword(
     String email,
     String password,
@@ -124,11 +124,25 @@ class AuthFirebaseApi extends AbstractAuthRepository {
   /// Returns a [UserModel] if the sign-up is successful, or `null` if it fails.
   ///
   /// Throws an exception if an error occurs during the sign-up process.
-  @override
   Future<UserModel?> signUpWithEmailAndPassword(
     String email,
     String password,
   ) async {
+    // Check beta status and user count
+    final remoteConfig = sl<RemoteConfigService>();
+    if (!remoteConfig.isSignupEnabled) {
+      throw Exception(
+          'Beta access is currently full. Please join the waitlist.');
+    }
+
+    // Check dynamic user count limit
+    final userCountQuery = await _usersCollection.count().get();
+    final currentCount = userCountQuery.count ?? 0;
+    if (currentCount >= remoteConfig.maxAllowedUsers) {
+      throw Exception(
+          'Beta user limit (${remoteConfig.maxAllowedUsers}) reached. Please join the waitlist.');
+    }
+
     try {
       final UserCredential userCredential = await _firebaseAuth
           .createUserWithEmailAndPassword(email: email, password: password);
@@ -149,7 +163,6 @@ class AuthFirebaseApi extends AbstractAuthRepository {
   /// Returns a [UserModel] if the sign-in is successful, or `null` if it fails.
   ///
   /// Throws an exception if an error occurs during the sign-in process.
-  @override
   Future<UserModel?> signInWithGoogle() async {
     try {
       final GoogleSignInResult? googleResult = await _getGoogleSignInResult();
@@ -197,6 +210,27 @@ class AuthFirebaseApi extends AbstractAuthRepository {
       ///
       /// Throws an exception if saving the tokens fails.
       await _saveGoogleTokens(user, googleAuth);
+
+      // Check if user is old or new
+      final userDoc = await _usersCollection.doc(user.uid).get();
+      if (!userDoc.exists) {
+        // New User - Check if signups enabled
+        final remoteConfig = sl<RemoteConfigService>();
+        if (!remoteConfig.isSignupEnabled) {
+          await user.delete(); // Clean up the auth record
+          throw Exception(
+              'Beta access is currently full. Please join the waitlist.');
+        }
+
+        // Check dynamic user count limit
+        final userCountQuery = await _usersCollection.count().get();
+        final currentCount = userCountQuery.count ?? 0;
+        if (currentCount >= remoteConfig.maxAllowedUsers) {
+          await user.delete();
+          throw Exception(
+              'Beta user limit (${remoteConfig.maxAllowedUsers}) reached. Please join the waitlist.');
+        }
+      }
 
       /// Handles the onboarding process for users associated with multiple clinics.
       ///
@@ -392,16 +426,15 @@ class AuthFirebaseApi extends AbstractAuthRepository {
       });
     }
 
-    final clinicIds = allClinicIds.toList();
     final primaryClinicId = firstClinicId;
 
     // Write minimal user data - backend will handle the rest via invitation acceptance
+    // Note: Removed clinicIds field - using only clinics array with map structure
     await docRef.set({
       'email': user.email,
       'displayName': user.displayName,
       'photoURL': user.photoURL,
       'createdAt': Timestamp.fromDate(DateTime.now().toUtc()),
-      'clinicIds': clinicIds,
       'primaryClinicId': primaryClinicId,
     });
   }
@@ -422,19 +455,15 @@ class AuthFirebaseApi extends AbstractAuthRepository {
       'adminEmail': user.email,
     });
 
-    final clinicIds = [newClinicRef.id];
     final primaryClinicId = newClinicRef.id;
 
     // Create user document with clinic membership
-    // Note: 'clinics' array is kept for legacy compatibility but role is removed/simplified in new arch
-    // Ideally we'd remove 'role': 'Admin' from here if we strictly follow the new path,
-    // but keeping it harmlessly for now avoids breaking other legacy readers if any exist.
+    // Note: Removed clinicIds field - using only clinics array with map structure
     await docRef.set({
       'email': user.email,
       'displayName': user.displayName,
       'photoURL': user.photoURL,
       'createdAt': Timestamp.fromDate(DateTime.now().toUtc()),
-      'clinicIds': clinicIds,
       'primaryClinicId': primaryClinicId,
       'clinics': [
         {
@@ -468,7 +497,7 @@ class AuthFirebaseApi extends AbstractAuthRepository {
       // We might want to rethrow or handle this more gracefully
     }
 
-    return {'clinicIds': clinicIds, 'primaryClinicId': primaryClinicId};
+    return {'primaryClinicId': primaryClinicId};
   }
 
   /// Saves authentication tokens (accessToken, idToken) to local storage.
@@ -491,7 +520,6 @@ class AuthFirebaseApi extends AbstractAuthRepository {
   /// authentication state associated with the current session.
   ///
   /// Throws an [Exception] if the sign-out process fails.
-  @override
   Future<void> signOut() async {
     await _firebaseAuth.signOut();
 
@@ -516,7 +544,6 @@ class AuthFirebaseApi extends AbstractAuthRepository {
   }
 
   /// Deletes the currently authenticated user.
-  @override
   Future<void> deleteCurrentUser() async {
     final user = _firebaseAuth.currentUser;
     if (user != null) {
@@ -527,7 +554,6 @@ class AuthFirebaseApi extends AbstractAuthRepository {
   }
 
   /// Returns the current authenticated user as a Firebase [User], or null if not signed in.
-  @override
   Future<UserModel?> getCurrentUser() async {
     final user = _firebaseAuth.currentUser;
     if (user == null) return null;
@@ -601,7 +627,6 @@ class AuthFirebaseApi extends AbstractAuthRepository {
   }
 
   /// Updates the current user's display name and/or photo URL.
-  @override
   Future<void> updateProfile({String? displayName, String? photoURL}) async {
     final user = _firebaseAuth.currentUser;
     if (user != null) {
@@ -630,7 +655,6 @@ class AuthFirebaseApi extends AbstractAuthRepository {
   ///   }
   /// });
   /// ```
-  @override
   Stream<UserModel?> authStateChanges() {
     return _firebaseAuth.authStateChanges().asyncMap((user) async {
       if (user == null) return null;

--- a/lib/src/features/auth/data/repositories/auth_repositories_impl.dart
+++ b/lib/src/features/auth/data/repositories/auth_repositories_impl.dart
@@ -1,3 +1,6 @@
+import 'package:dartz/dartz.dart';
+import 'package:dr_copilot/src/core/error/error_handler.dart';
+import 'package:dr_copilot/src/core/error/failures.dart';
 import 'package:dr_copilot/src/features/auth/domain/models/user_model.dart';
 import 'package:dr_copilot/src/features/auth/domain/repositories/auth_repository.dart';
 import 'package:dr_copilot/src/features/auth/data/remote/auth_firebase_api.dart';
@@ -8,18 +11,34 @@ class AuthRepositoryImpl implements AbstractAuthRepository {
   AuthRepositoryImpl(this.api);
 
   @override
-  Future<UserModel?> signInWithEmailAndPassword(String email, String password) {
-    return api.signInWithEmailAndPassword(email, password);
+  Future<Either<Failure, UserModel?>> signInWithEmailAndPassword(
+      String email, String password) async {
+    try {
+      final user = await api.signInWithEmailAndPassword(email, password);
+      return Right(user);
+    } catch (e) {
+      return Left(ErrorHandler.mapExceptionToFailure(e));
+    }
   }
 
   @override
-  Future<void> signOut() {
-    return api.signOut();
+  Future<Either<Failure, void>> signOut() async {
+    try {
+      await api.signOut();
+      return const Right(null);
+    } catch (e) {
+      return Left(ErrorHandler.mapExceptionToFailure(e));
+    }
   }
 
   @override
-  Future<UserModel?> getCurrentUser() {
-    return api.getCurrentUser();
+  Future<Either<Failure, UserModel?>> getCurrentUser() async {
+    try {
+      final user = await api.getCurrentUser();
+      return Right(user);
+    } catch (e) {
+      return Left(ErrorHandler.mapExceptionToFailure(e));
+    }
   }
 
   @override
@@ -28,23 +47,44 @@ class AuthRepositoryImpl implements AbstractAuthRepository {
   }
 
   @override
-  Future<UserModel?> signInWithGoogle() {
-    return api.signInWithGoogle();
+  Future<Either<Failure, UserModel?>> signInWithGoogle() async {
+    try {
+      final user = await api.signInWithGoogle();
+      return Right(user);
+    } catch (e) {
+      return Left(ErrorHandler.mapExceptionToFailure(e));
+    }
   }
 
   @override
-  Future<UserModel?> signUpWithEmailAndPassword(String email, String password) {
-    return api.signUpWithEmailAndPassword(email, password);
+  Future<Either<Failure, UserModel?>> signUpWithEmailAndPassword(
+      String email, String password) async {
+    try {
+      final user = await api.signUpWithEmailAndPassword(email, password);
+      return Right(user);
+    } catch (e) {
+      return Left(ErrorHandler.mapExceptionToFailure(e));
+    }
   }
 
   @override
-  Future<void> deleteCurrentUser() {
-    return api.deleteCurrentUser();
+  Future<Either<Failure, void>> deleteCurrentUser() async {
+    try {
+      await api.deleteCurrentUser();
+      return const Right(null);
+    } catch (e) {
+      return Left(ErrorHandler.mapExceptionToFailure(e));
+    }
   }
 
   @override
-  Future<void> updateProfile({String? displayName, String? photoURL}) {
-    return api.updateProfile(displayName: displayName, photoURL: photoURL);
+  Future<Either<Failure, void>> updateProfile(
+      {String? displayName, String? photoURL}) async {
+    try {
+      await api.updateProfile(displayName: displayName, photoURL: photoURL);
+      return const Right(null);
+    } catch (e) {
+      return Left(ErrorHandler.mapExceptionToFailure(e));
+    }
   }
 }
-

--- a/lib/src/features/auth/domain/models/clinic_model.g.dart
+++ b/lib/src/features/auth/domain/models/clinic_model.g.dart
@@ -7,13 +7,13 @@ part of 'clinic_model.dart';
 // **************************************************************************
 
 ClinicModel _$ClinicModelFromJson(Map<String, dynamic> json) => ClinicModel(
-  id: json['id'] as String,
-  name: json['name'] as String,
-  location: json['location'] as String?,
-  ownerId: json['ownerId'] as String,
-  adminEmail: json['adminEmail'] as String,
-  createdAt: const TimestampConverter().fromJson(json['createdAt']),
-);
+      id: json['id'] as String,
+      name: json['name'] as String,
+      location: json['location'] as String?,
+      ownerId: json['ownerId'] as String,
+      adminEmail: json['adminEmail'] as String,
+      createdAt: const TimestampConverter().fromJson(json['createdAt']),
+    );
 
 Map<String, dynamic> _$ClinicModelToJson(ClinicModel instance) =>
     <String, dynamic>{
@@ -23,13 +23,11 @@ Map<String, dynamic> _$ClinicModelToJson(ClinicModel instance) =>
       'ownerId': instance.ownerId,
       'adminEmail': instance.adminEmail,
       'createdAt': _$JsonConverterToJson<dynamic, Timestamp>(
-        instance.createdAt,
-        const TimestampConverter().toJson,
-      ),
+          instance.createdAt, const TimestampConverter().toJson),
     };
 
 Json? _$JsonConverterToJson<Json, Value>(
   Value? value,
   Json? Function(Value value) toJson,
-) => value == null ? null : toJson(value);
-
+) =>
+    value == null ? null : toJson(value);

--- a/lib/src/features/auth/domain/models/permission_enum.dart
+++ b/lib/src/features/auth/domain/models/permission_enum.dart
@@ -2,68 +2,223 @@
 // These permissions are stored in the database for each user/member.
 
 enum AppPermission {
-  // Patients
+  // --- PATIENTS ---
+  /// View the complete list of patients in the clinic.
   viewAllPatients,
+
+  /// View only patients assigned strictly to the current user (if applicable).
   viewOwnPatients,
+
+  /// Register a new patient in the clinic.
   createPatient,
+
+  /// Update existing patient demographic or assignment details.
   updatePatient,
+
+  /// Soft-delete or archive a patient record.
   deletePatient,
 
-  // Sessions
+  // --- SESSIONS ---
+  /// View sessions across the entire clinic.
   viewAllSessions,
+
+  /// View sessions where the current user is the provider.
   viewOwnSessions,
+
+  /// Schedule or record a new clinical session.
   createSession,
+
+  /// Modify session details (notes, time, status).
   updateSession,
+
+  /// Remove a session record.
   deleteSession,
 
-  // Evaluations
+  // --- EVALUATIONS ---
+  /// View clinical evaluations/assessments for all patients.
   viewAllEvaluations,
+
+  /// View evaluations performed by the current user.
   viewOwnEvaluations,
+
+  /// Perform and record a new evaluation.
   createEvaluation,
+
+  /// Edit an existing evaluation.
   updateEvaluation,
+
+  /// Delete an evaluation record.
   deleteEvaluation,
 
-  // Financials
+  // --- FINANCIALS ---
+  /// Access the financial dashboard, view invoices, and transaction history.
   viewFinancials,
+
+  /// @Deprecated('Use add/edit/deleteFinancialEntry instead')
   manageInvoices,
+
+  /// View aggregated financial reports and summaries.
   viewReports,
+
+  /// View visual financial charts and analytics.
   viewCharts,
 
-  // Calendar
+  // --- CALENDAR ---
+  /// View the clinic's master calendar or appointment book.
   viewCalendar,
+
+  /// Schedule items on the global calendar.
   addCalendarEvent,
+
+  /// Reschedule or modify calendar events.
   editCalendarEvent,
+
+  /// Cancel or remove calendar events.
   deleteCalendarEvent,
 
-  // Copilot
+  // --- COPILOT AI ---
+  /// Access and interact with the AI assistant.
   useCopilot,
 
-  // Notifications
+  // --- NOTIFICATIONS ---
+  /// View the notification center history.
   viewNotifications,
+
+  /// Configure notification settings.
   manageNotifications,
+
+  /// Send a manual message notification to patients/staff.
   sendNotificationMessage,
+
+  /// Send appointment reminders manually.
   sendNotificationAppointment,
+
+  /// Check or send general reminders.
   sendNotificationReminder,
 
-  // Settings
+  // --- SETTINGS ---
+  /// View clinic configuration and settings.
   viewSettings,
+
+  /// Modify clinic configuration (e.g., logo, operating hours).
   editSettings,
 
-  // Admin
+  // --- ADMIN & STAFF ---
+  /// Add, remove, or edit staff member profiles.
   manageStaff,
+
+  /// Manage user accounts (invites, role changes).
   manageUsers,
+
+  /// Change the role of a user (e.g., Staff to Doctor).
   assignRoles,
+
+  /// Grant or revoke specific permissions for a user.
   assignPermissions,
+
+  /// Access critical system-wide settings (Owner level).
   manageSettings,
 
-  // Teams
+  // --- TEAMS ---
+  /// Create or delete chat/collaboration teams.
   manageTeams,
+
+  /// Create a new team.
   createTeam,
+
+  /// Archive a team (read-only mode).
   archiveTeam,
+
+  /// Activate an archived team.
   unarchiveTeam,
 
-  // Help & Support
+  // --- MEDICAL FILES ---
+  /// View attached files (PDFs, Images) in patient records.
+  viewMedicalFiles,
+
+  /// Upload new documents to patient records.
+  addMedicalFile,
+
+  /// Rename or modify metadata of uploaded files.
+  editMedicalFile,
+
+  /// Remove files from patient records.
+  deleteMedicalFile,
+
+  // --- MEDICATIONS ---
+  /// View the clinic's medication list/formulary.
+  viewMedications,
+
+  /// Add new drugs to the formulary.
+  addMedication,
+
+  /// Edit details of existing medications.
+  editMedication,
+
+  /// Remove medications from the formulary.
+  deleteMedication,
+
+  // --- RECYCLE BIN ---
+  /// Access deleted items pending permanent removal.
+  viewRecycleBin,
+
+  /// Restore a deleted item to active status.
+  restoreRecycleBinItem,
+
+  /// Permanently destroy data (GDPR/Compliance).
+  permanentDeleteRecycleBinItem,
+
+  // --- FINANCIALS (GRANULAR) ---
+  /// Record a new financial transaction (invoice/payment).
+  addFinancialEntry,
+
+  /// Correct or update a financial record.
+  editFinancialEntry,
+
+  /// Void or remove a financial record.
+  deleteFinancialEntry,
+
+  // --- CLINICAL REPORTS ---
+  /// View specialized clinical reports (Phase 2 feature).
+  viewClinicalReports,
+
+  /// Generate a new clinical report.
+  addClinicalReport,
+
+  /// Modify an existing clinical report.
+  editClinicalReport,
+
+  /// Delete a clinical report.
+  deleteClinicalReport,
+
+  // --- DOCTORS DIRECTORY ---
+  /// View the public list of doctors in the clinic.
+  viewDoctors,
+
+  /// Add or edit doctor profiles in the directory.
+  manageDoctors,
+
+  // --- INVITATIONS ---
+  /// View pending and sent invitations.
+  viewInvitations,
+
+  /// Invite a new user to join the clinic via email.
+  sendInvitation,
+
+  /// Cancel a sent invitation before it is accepted.
+  revokeInvitation,
+
+  // --- SUBSCRIPTION ---
+  /// View current billing plan and usage quotas.
+  viewSubscription,
+
+  /// Upgrade, downgrade, or cancel the subscription.
+  manageSubscription,
+
+  // --- HELP & SUPPORT ---
+  /// Access help documentation/FAQ.
   viewHelp,
+
+  /// Contact support or open tickets.
   accessSupport,
 }
-

--- a/lib/src/features/auth/domain/models/role_defaults.dart
+++ b/lib/src/features/auth/domain/models/role_defaults.dart
@@ -9,7 +9,6 @@ import 'package:dr_copilot/src/features/notifications/domain/models/notification
 class RoleDefaults {
   static List<AppPermission> getPermissionsForRole(AppRole role) {
     switch (role) {
-      case AppRole.superAdmin:
       case AppRole.admin:
         return [
           ...AppPermission.values,
@@ -74,10 +73,6 @@ class RoleDefaults {
   static List<NotificationTargetType> getAllowedNotificationTargets(
     AppRole role,
   ) {
-    if (role == AppRole.superAdmin) {
-      return NotificationTargetType.values;
-    }
-
     if (role == AppRole.admin) {
       return [
         NotificationTargetType.ownerClinics,
@@ -95,4 +90,3 @@ class RoleDefaults {
     ];
   }
 }
-

--- a/lib/src/features/auth/domain/models/role_enum.dart
+++ b/lib/src/features/auth/domain/models/role_enum.dart
@@ -4,7 +4,6 @@ import 'package:json_annotation/json_annotation.dart';
 
 /// Enum representing all roles in the app.
 enum AppRole {
-  superAdmin,
   admin,
   doctor,
   staff,
@@ -14,8 +13,6 @@ enum AppRole {
   /// Maps [AppRole] enum to its string value (as used in Firestore and role_permissions.dart).
   String roleToString(AppRole role) {
     switch (role) {
-      case AppRole.superAdmin:
-        return 'superAdmin';
       case AppRole.admin:
         return 'admin';
       case AppRole.doctor:
@@ -29,7 +26,6 @@ enum AppRole {
     }
   }
 
-  /// Optionally, add a function to parse a string to Role enum.
   AppRole? roleFromString(String value) {
     for (final role in AppRole.values) {
       if (roleToString(role) == value) return role;
@@ -50,4 +46,3 @@ class RoleListJsonConverter
   List<dynamic> toJson(List<AppRole> object) =>
       object.map((e) => AppRole.admin.roleToString(e)).toList();
 }
-

--- a/lib/src/features/auth/domain/models/user_model.dart
+++ b/lib/src/features/auth/domain/models/user_model.dart
@@ -188,4 +188,3 @@ class UserModel {
         .toList();
   }
 }
-

--- a/lib/src/features/auth/domain/models/user_model.g.dart
+++ b/lib/src/features/auth/domain/models/user_model.g.dart
@@ -7,26 +7,25 @@ part of 'user_model.dart';
 // **************************************************************************
 
 UserModel _$UserModelFromJson(Map<String, dynamic> json) => UserModel(
-  uid: json['uid'] as String,
-  email: json['email'] as String?,
-  displayName: json['displayName'] as String?,
-  photoURL: json['photoURL'] as String?,
-  clinics: (json['clinics'] as List<dynamic>?)
-      ?.map((e) => e as Map<String, dynamic>)
-      .toList(),
-  primaryClinicId: json['primaryClinicId'] as String?,
-  clinicIds: (json['clinicIds'] as List<dynamic>?)
-      ?.map((e) => e as String)
-      .toList(),
-);
+      uid: json['uid'] as String,
+      email: json['email'] as String?,
+      displayName: json['displayName'] as String?,
+      photoURL: json['photoURL'] as String?,
+      clinics: (json['clinics'] as List<dynamic>?)
+          ?.map((e) => e as Map<String, dynamic>)
+          .toList(),
+      primaryClinicId: json['primaryClinicId'] as String?,
+      clinicIds: (json['clinicIds'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList(),
+    );
 
 Map<String, dynamic> _$UserModelToJson(UserModel instance) => <String, dynamic>{
-  'uid': instance.uid,
-  'email': instance.email,
-  'displayName': instance.displayName,
-  'photoURL': instance.photoURL,
-  'clinics': instance.clinics,
-  'primaryClinicId': instance.primaryClinicId,
-  'clinicIds': instance.clinicIds,
-};
-
+      'uid': instance.uid,
+      'email': instance.email,
+      'displayName': instance.displayName,
+      'photoURL': instance.photoURL,
+      'clinics': instance.clinics,
+      'primaryClinicId': instance.primaryClinicId,
+      'clinicIds': instance.clinicIds,
+    };

--- a/lib/src/features/auth/domain/repositories/auth_repository.dart
+++ b/lib/src/features/auth/domain/repositories/auth_repository.dart
@@ -1,5 +1,6 @@
+import 'package:dartz/dartz.dart';
+import 'package:dr_copilot/src/core/error/failures.dart';
 import 'package:dr_copilot/src/features/auth/domain/models/user_model.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 
 /// An abstract repository that defines authentication-related operations.
 ///
@@ -8,31 +9,31 @@ import 'package:firebase_auth/firebase_auth.dart';
 abstract class AbstractAuthRepository {
   /// Authenticates a user with the provided [email] and [password].
   ///
-  /// Returns a [User] object if authentication is successful.
-  ///
-  /// Throws an [AuthException] if the login fails due to invalid credentials
-  /// or other authentication errors.
-  Future<UserModel?> signInWithEmailAndPassword(String email, String password);
+  /// Returns a [Right(User)] object if authentication is successful.
+  /// Returns a [Left(Failure)] if the login fails.
+  Future<Either<Failure, UserModel?>> signInWithEmailAndPassword(
+      String email, String password);
 
   /// Signs out the currently authenticated user.
-  Future<void> signOut();
+  Future<Either<Failure, void>> signOut();
 
   /// Returns the current authenticated user, or null if not signed in.
-  Future<UserModel?> getCurrentUser();
+  Future<Either<Failure, UserModel?>> getCurrentUser();
 
   /// Returns a stream of authentication state changes as UserModel.
   Stream<UserModel?> authStateChanges();
 
   /// Signs in the user using Google authentication.
-  Future<UserModel?> signInWithGoogle();
+  Future<Either<Failure, UserModel?>> signInWithGoogle();
 
   /// Registers a new user with email and password.
-  Future<UserModel?> signUpWithEmailAndPassword(String email, String password);
+  Future<Either<Failure, UserModel?>> signUpWithEmailAndPassword(
+      String email, String password);
 
   /// Deletes the currently authenticated user.
-  Future<void> deleteCurrentUser();
+  Future<Either<Failure, void>> deleteCurrentUser();
 
   /// Updates the current user's display name and/or photo URL.
-  Future<void> updateProfile({String? displayName, String? photoURL});
+  Future<Either<Failure, void>> updateProfile(
+      {String? displayName, String? photoURL});
 }
-

--- a/lib/src/features/auth/domain/services/permission_service.dart
+++ b/lib/src/features/auth/domain/services/permission_service.dart
@@ -1,7 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:dr_copilot/src/features/auth/domain/models/role_permissions.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/foundation.dart';
+import 'package:dr_copilot/src/features/auth/domain/models/permission_enum.dart';
 
 /// Service for checking user permissions based on their assigned roles.
 ///
@@ -11,15 +11,71 @@ class PermissionService {
   final FirebaseAuth _auth;
   final FirebaseFirestore _firestore;
 
+  // Permission cache: clinicId -> list of permission names
+  final Map<String, List<String>> _permissionCache = {};
+  DateTime? _cacheExpiry;
+  static const _cacheDuration = Duration(minutes: 5);
+
   PermissionService({
     FirebaseAuth? auth,
     FirebaseFirestore? firestore,
   })  : _auth = auth ?? FirebaseAuth.instance,
         _firestore = firestore ?? FirebaseFirestore.instance;
 
-  /// Checks if the current user has a specific permission.
+  /// Synchronous permission check using cached permissions.
   ///
-  /// [permission] - The permission string to check (e.g., 'can_add_patient')
+  /// This is the preferred method for UI permission checks.
+  /// Returns false if permissions are not cached yet.
+  ///
+  /// [permission] - The AppPermission enum to check
+  /// [clinicId] - Optional clinic ID, falls back to user's primary clinic
+  bool hasPermissionSync(AppPermission permission, {String? clinicId}) {
+    final cached = _getCachedPermissions(clinicId);
+    final hasIt = cached?.contains(permission.name) ?? false;
+
+    if (!hasIt && cached != null) {
+      debugPrint(
+          '[PermissionService] Permission check FAILED: ${permission.name} not in cached permissions');
+      debugPrint('[PermissionService] User has: $cached');
+    }
+
+    return hasIt;
+  }
+
+  /// Get cached permissions for a clinic.
+  List<String>? _getCachedPermissions(String? clinicId) {
+    // Check if cache is expired
+    if (_cacheExpiry != null && DateTime.now().isAfter(_cacheExpiry!)) {
+      debugPrint('[PermissionService] Cache expired, clearing...');
+      _permissionCache.clear();
+      _cacheExpiry = null;
+      return null;
+    }
+
+    final key = clinicId ?? 'default';
+    return _permissionCache[key];
+  }
+
+  /// Set cached permissions for a clinic.
+  void _setCachedPermissions(String? clinicId, List<String> permissions) {
+    final key = clinicId ?? 'default';
+    _permissionCache[key] = permissions;
+    _cacheExpiry = DateTime.now().add(_cacheDuration);
+    debugPrint(
+        '[PermissionService] Cached ${permissions.length} permissions for clinic $key');
+  }
+
+  /// Clear the permission cache.
+  /// Call this on logout or when permissions change.
+  void clearCache() {
+    debugPrint('[PermissionService] Clearing permission cache');
+    _permissionCache.clear();
+    _cacheExpiry = null;
+  }
+
+  /// Checks if the current user has a specific permission (async).
+  ///
+  /// [permission] - The permission string to check (e.g., 'viewAllPatients')
   /// [clinicId] - Optional clinic ID to check clinic-specific roles
   ///
   /// Returns true if user has the permission, false otherwise.
@@ -73,118 +129,67 @@ class PermissionService {
   ///
   /// Returns a list of all permission strings the user has.
   /// Returns null on error.
+  /// Automatically caches results for better performance.
   Future<List<String>?> getUserPermissions({String? clinicId}) async {
     final userId = _auth.currentUser?.uid;
     if (userId == null) return null;
 
     try {
-      // 1. Check if user is the OWNER of the clinic
-      if (clinicId != null) {
+      // Check cache first
+      final cached = _getCachedPermissions(clinicId);
+      if (cached != null) {
         debugPrint(
-            '[PermissionService] Checking owner for clinicId: $clinicId, userId: $userId');
-        final clinicDoc =
-            await _firestore.collection('clinics').doc(clinicId).get();
-        if (clinicDoc.exists) {
-          final ownerId = clinicDoc.data()?['ownerId'];
-          debugPrint('[PermissionService] Clinic ownerId: $ownerId');
-          if (ownerId == userId) {
+            '[PermissionService] Returning ${cached.length} cached permissions');
+        return cached;
+      }
+
+      // If no clinicId provided, try to get from user's primary clinic
+      String? targetClinicId = clinicId;
+      if (targetClinicId == null) {
+        final userDoc = await _firestore.collection('users').doc(userId).get();
+        targetClinicId = userDoc.data()?['primaryClinicId'];
+      }
+
+      if (targetClinicId == null) {
+        debugPrint(
+            '[PermissionService] No clinicId available - cannot load permissions');
+        return null;
+      }
+
+      debugPrint(
+          '[PermissionService] Loading permissions from Firestore for userId: $userId, clinicId: $targetClinicId');
+
+      // Get permissions directly from clinic members subcollection
+      final memberDoc = await _firestore
+          .collection('clinics')
+          .doc(targetClinicId)
+          .collection('members')
+          .doc(userId)
+          .get();
+
+      if (memberDoc.exists) {
+        final memberData = memberDoc.data();
+        debugPrint('[PermissionService] Found member doc');
+
+        if (memberData != null && memberData['permissions'] != null) {
+          if (memberData['permissions'] is List) {
+            final permissions = List<String>.from(memberData['permissions']);
             debugPrint(
-                '[PermissionService] User is OWNER - granting all permissions');
-            // Owners get ALL permissions implicitly
-            return [
-              'can_add_patient',
-              'can_edit_patient',
-              'can_delete_patient',
-              'can_view_patient',
-              'can_add_session',
-              'can_edit_session',
-              'can_delete_session',
-              'can_view_session',
-              'can_add_evaluation',
-              'can_edit_evaluation',
-              'can_delete_evaluation',
-              'can_view_evaluation',
-              'can_view_analytics',
-              'can_manage_clinic',
-              'can_manage_staff',
-              'can_assign_roles',
-              'can_view_financials',
-              'can_use_copilot'
-            ];
+                '[PermissionService] Loaded ${permissions.length} permissions from Firestore');
+
+            // Cache the permissions
+            _setCachedPermissions(targetClinicId, permissions);
+
+            return permissions;
           }
         } else {
-          debugPrint(
-              '[PermissionService] Clinic doc does not exist for $clinicId');
+          debugPrint('[PermissionService] No permissions field in member doc');
         }
       } else {
-        debugPrint(
-            '[PermissionService] clinicId is NULL - skipping owner check');
+        debugPrint('[PermissionService] Member doc not found');
       }
 
-      // 2. Initial role set & direct permissions
-      List<String> userRoles = [];
-      Set<String> allPermissions = {};
-
-      // 3. Try to get roles and permissions from clinic members subcollection
-      if (clinicId != null) {
-        final memberDoc = await _firestore
-            .collection('clinics')
-            .doc(clinicId)
-            .collection('members')
-            .doc(userId)
-            .get();
-
-        if (memberDoc.exists) {
-          final memberData = memberDoc.data();
-          debugPrint('[PermissionService] Found member doc: $memberData');
-
-          if (memberData != null) {
-            // Handle Roles
-            if (memberData['role'] != null) {
-              if (memberData['role'] is String) {
-                userRoles.add(memberData['role'] as String);
-              } else if (memberData['role'] is List) {
-                userRoles.addAll(List<String>.from(memberData['role']));
-              }
-            }
-            if (memberData['roles'] != null && memberData['roles'] is List) {
-              userRoles.addAll(List<String>.from(memberData['roles']));
-            }
-
-            // Handle Direct Permissions
-            if (memberData['permissions'] != null) {
-              debugPrint('[PermissionService] Found direct permissions list');
-              if (memberData['permissions'] is List) {
-                allPermissions
-                    .addAll(List<String>.from(memberData['permissions']));
-              }
-            }
-          }
-        }
-      }
-
-      // 4. Fallback: Check user document for global roles (legacy/backup)
-      if (userRoles.isEmpty && allPermissions.isEmpty) {
-        final userDoc = await _firestore.collection('users').doc(userId).get();
-        final userData = userDoc.data();
-        if (userData != null && userData['roles'] != null) {
-          try {
-            userRoles = List<String>.from(userData['roles'] as List);
-          } catch (e) {
-            // Ignore parsing errors
-          }
-        }
-      }
-
-      debugPrint('[PermissionService] Final user roles: $userRoles');
-
-      // 5. Add Key-Based Permissions from Roles
-      for (final role in userRoles) {
-        final permissions = rolePermissions[role] ?? [];
-        allPermissions.addAll(permissions);
-      }
-
-      return allPermissions.toList();
+      return [];
     } catch (e) {
       debugPrint('[PermissionService] Error getting user permissions: $e');
       return null;

--- a/lib/src/features/auth/domain/usecases/login_usecase.dart
+++ b/lib/src/features/auth/domain/usecases/login_usecase.dart
@@ -1,3 +1,5 @@
+import 'package:dartz/dartz.dart';
+import 'package:dr_copilot/src/core/error/failures.dart';
 import 'package:dr_copilot/src/features/auth/domain/repositories/auth_repository.dart';
 import 'package:dr_copilot/src/features/auth/domain/models/user_model.dart';
 
@@ -22,21 +24,20 @@ class AuthUseCase {
 
   /// Authenticates a user with the provided [email] and [password].
   ///
-  /// Returns a [UserModel] object if authentication is successful.
-  ///
-  /// Throws an exception if authentication fails.
-  Future<UserModel?> signInWithEmailAndPassword(
+  /// Returns a [Right(UserModel)] object if authentication is successful.
+  /// Returns a [Left(Failure)] if authentication fails.
+  Future<Either<Failure, UserModel?>> signInWithEmailAndPassword(
       String email, String password) async {
     return await repository.signInWithEmailAndPassword(email, password);
   }
 
   /// Signs out the currently authenticated user.
-  Future<void> signOut() async {
-    await repository.signOut();
+  Future<Either<Failure, void>> signOut() async {
+    return await repository.signOut();
   }
 
   /// Returns the current authenticated user, or null if not signed in.
-  Future<UserModel?> getCurrentUser() async {
+  Future<Either<Failure, UserModel?>> getCurrentUser() async {
     return await repository.getCurrentUser();
   }
 
@@ -46,25 +47,25 @@ class AuthUseCase {
   }
 
   /// Signs in the user using Google authentication.
-  Future<UserModel?> signInWithGoogle() async {
+  Future<Either<Failure, UserModel?>> signInWithGoogle() async {
     return await repository.signInWithGoogle();
   }
 
   /// Registers a new user with email and password.
-  Future<UserModel?> signUpWithEmailAndPassword(
+  Future<Either<Failure, UserModel?>> signUpWithEmailAndPassword(
       String email, String password) async {
     return await repository.signUpWithEmailAndPassword(email, password);
   }
 
   /// Deletes the currently authenticated user.
-  Future<void> deleteCurrentUser() async {
-    await repository.deleteCurrentUser();
+  Future<Either<Failure, void>> deleteCurrentUser() async {
+    return await repository.deleteCurrentUser();
   }
 
   /// Updates the current user's display name and/or photo URL.
-  Future<void> updateProfile({String? displayName, String? photoURL}) async {
-    await repository.updateProfile(
+  Future<Either<Failure, void>> updateProfile(
+      {String? displayName, String? photoURL}) async {
+    return await repository.updateProfile(
         displayName: displayName, photoURL: photoURL);
   }
 }
-

--- a/lib/src/features/auth/presentation/bloc/auth_bloc.dart
+++ b/lib/src/features/auth/presentation/bloc/auth_bloc.dart
@@ -27,27 +27,34 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
   ///
   /// @param event The event to sign in with Google.
   /// @param emit The function to emit states.
+  /// Handles the SignInWithGoogle event.
+  ///
+  /// @param event The event to sign in with Google.
+  /// @param emit The function to emit states.
   void _signInWithGoogle(
     SignInWithGoogle event,
     Emitter<AuthState> emit,
   ) async {
-    try {
-      emit(const AuthLoading());
-      debugPrint('SignInWithGoogle event triggered');
-      final user = await authUseCase.signInWithGoogle();
-      if (user != null) {
-        // Initialize FCM for the user
-        await _initializeFCM(user.uid);
+    emit(const AuthLoading());
+    debugPrint('SignInWithGoogle event triggered');
+    final result = await authUseCase.signInWithGoogle();
 
-        // Optionally store user data if needed
-        emit(AuthSignedIn(message: 'User signed in successfully', user: user));
-      } else {
-        emit(const AuthError(message: 'Google sign-in aborted'));
-      }
-    } catch (error) {
-      emit(AuthError(message: error.toString()));
-      debugPrint('Google sign-in error: $error');
-    }
+    await result.fold(
+      (failure) async {
+        debugPrint('Google sign-in error: ${failure.message}');
+        emit(AuthError(message: failure.message));
+      },
+      (user) async {
+        if (user != null) {
+          // Initialize FCM for the user
+          await _initializeFCM(user.uid);
+          emit(
+              AuthSignedIn(message: 'User signed in successfully', user: user));
+        } else {
+          emit(const AuthError(message: 'Google sign-in aborted'));
+        }
+      },
+    );
   }
 
   /// Handles the SignInWithEmailAndPassword event.
@@ -58,25 +65,25 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
     SignInWithEmailAndPassword event,
     Emitter<AuthState> emit,
   ) async {
-    try {
-      emit(const AuthLoading());
-      debugPrint('SignInWithEmailAndPassword event triggered');
-      final user = await authUseCase.signInWithEmailAndPassword(
-        event.email,
-        event.password,
-      );
+    emit(const AuthLoading());
+    debugPrint('SignInWithEmailAndPassword event triggered');
+    final result = await authUseCase.signInWithEmailAndPassword(
+      event.email,
+      event.password,
+    );
+
+    await result.fold((failure) async {
+      debugPrint('Email/password sign-in error: ${failure.message}');
+      emit(AuthError(message: failure.message));
+    }, (user) async {
       if (user != null) {
         // Initialize FCM for the user
         await _initializeFCM(user.uid);
-
         emit(AuthSignedIn(message: 'User signed in successfully', user: user));
       } else {
         emit(const AuthError(message: 'Sign-in failed'));
       }
-    } catch (error) {
-      emit(AuthError(message: error.toString()));
-      debugPrint('Email/password sign-in error: $error');
-    }
+    });
   }
 
   /// Initialize FCM service for the user
@@ -95,30 +102,37 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
   /// @param event The event to sign out.
   /// @param emit The function to emit states.
   void _onSignOut(SignOutEvent event, Emitter<AuthState> emit) async {
-    try {
-      debugPrint('Sign out event triggered');
-      final user = await authUseCase.getCurrentUser();
+    debugPrint('Sign out event triggered');
+
+    final currentUserResult = await authUseCase.getCurrentUser();
+
+    // Attempt to clear cache for current user photo
+    currentUserResult.fold((l) => null, // Ignore failure here
+        (user) async {
       if (user != null && user.photoURL != null) {
         await CachedNetworkImage.evictFromCache(user.photoURL!);
       }
+    });
 
-      // Clean up FCM (delete token and stop listeners)
-      try {
-        final fcmService = GetIt.instance<FCMService>();
-        await fcmService.deleteToken();
-        debugPrint('[AuthBloc] FCM cleaned up');
-      } catch (e) {
-        debugPrint('[AuthBloc] Error cleaning up FCM: $e');
-      }
+    // Clean up FCM (delete token and stop listeners)
+    try {
+      final fcmService = GetIt.instance<FCMService>();
+      await fcmService.deleteToken();
+      debugPrint('[AuthBloc] FCM cleaned up');
+    } catch (e) {
+      debugPrint('[AuthBloc] Error cleaning up FCM: $e');
+    }
 
-      await authUseCase.signOut();
+    final signOutResult = await authUseCase.signOut();
+
+    signOutResult.fold((failure) {
+      debugPrint('Sign-out error: ${failure.message}');
+      emit(AuthError(message: failure.message));
+    }, (_) {
       debugPrint('Sign-out successful');
       RoutingConfig.router.go('/');
       emit(AuthSignedOut());
-    } catch (e) {
-      debugPrint('Sign-out error: $e');
-      emit(AuthError(message: e.toString()));
-    }
+    });
   }
 
   /// Returns a stream of authentication state changes (UserModel? or null).
@@ -145,4 +159,3 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
     );
   }
 }
-

--- a/lib/src/features/auth/presentation/pages/beta_full_page.dart
+++ b/lib/src/features/auth/presentation/pages/beta_full_page.dart
@@ -1,0 +1,86 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class BetaFullPage extends StatelessWidget {
+  const BetaFullPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Container(
+        padding: const EdgeInsets.all(32),
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+            colors: [
+              Colors.white,
+              Theme.of(context).colorScheme.primaryContainer.withOpacity(0.2),
+            ],
+          ),
+        ),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Spacer(),
+            // Custom Icon
+            Container(
+              padding: const EdgeInsets.all(24),
+              decoration: BoxDecoration(
+                color: Colors.orange.withOpacity(0.1),
+                shape: BoxShape.circle,
+              ),
+              child: const Icon(
+                Icons.hourglass_top_rounded,
+                size: 64,
+                color: Colors.orange,
+              ),
+            ),
+            const SizedBox(height: 32),
+            Text(
+              'Beta Access Full',
+              style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                    color: Colors.black87,
+                  ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Thank you for your interest in Dr. Copilot. Due to high demand, we have temporarily paused new signups to ensure the best experience for our current users.',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                    color: Colors.black54,
+                    height: 1.5,
+                  ),
+            ),
+            const SizedBox(height: 32),
+            Text(
+              'Please check back later or contact support to join the waitlist.',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Colors.black45,
+                  ),
+            ),
+            const Spacer(),
+            OutlinedButton.icon(
+              onPressed: () {
+                final Uri emailLaunchUri = Uri(
+                  scheme: 'mailto',
+                  path: 'nourrehabcenter@gmail.com',
+                  query: 'subject=Dr. Copilot Waitlist Request',
+                );
+                launchUrl(emailLaunchUri);
+              },
+              icon: const Icon(Icons.mail_outline),
+              label: const Text('Join Waitlist via Email'),
+            ),
+            const SizedBox(height: 16),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/auth/presentation/pages/login_page.dart
+++ b/lib/src/features/auth/presentation/pages/login_page.dart
@@ -98,7 +98,7 @@ class _LoginPageState extends State<LoginPage> {
                                 width: 120,
                                 height: 120,
                                 placeholderBuilder: (context) => const Icon(
-                                  Icons.local_hospital,
+                                  Icons.local_hospital_outlined,
                                   size: 80,
                                   color: Colors.blue,
                                 ),
@@ -109,7 +109,9 @@ class _LoginPageState extends State<LoginPage> {
                         const SizedBox(height: 32),
                         Text(
                           'welcomeBack'.tr(),
-                          style: Theme.of(context).textTheme.headlineMedium
+                          style: Theme.of(context)
+                              .textTheme
+                              .headlineMedium
                               ?.copyWith(
                                 fontWeight: FontWeight.bold,
                                 color: Theme.of(context).colorScheme.primary,
@@ -119,12 +121,12 @@ class _LoginPageState extends State<LoginPage> {
                         const SizedBox(height: 8),
                         Text(
                           'signInToContinue'.tr(),
-                          style: Theme.of(context).textTheme.bodyMedium
-                              ?.copyWith(
-                                color: Theme.of(
-                                  context,
-                                ).colorScheme.onSurfaceVariant,
-                              ),
+                          style:
+                              Theme.of(context).textTheme.bodyMedium?.copyWith(
+                                    color: Theme.of(
+                                      context,
+                                    ).colorScheme.onSurfaceVariant,
+                                  ),
                           textAlign: TextAlign.center,
                         ),
                         const SizedBox(height: 48),
@@ -199,21 +201,25 @@ class _LoginPageState extends State<LoginPage> {
                           child: Column(
                             children: [
                               Icon(
-                                Icons.security,
+                                Icons.security_outlined,
                                 size: 32,
                                 color: Theme.of(context).colorScheme.primary,
                               ),
                               const SizedBox(height: 8),
                               Text(
                                 'secureAuthentication'.tr(),
-                                style: Theme.of(context).textTheme.titleSmall
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .titleSmall
                                     ?.copyWith(fontWeight: FontWeight.w600),
                                 textAlign: TextAlign.center,
                               ),
                               const SizedBox(height: 4),
                               Text(
                                 'googleAuthDescription'.tr(),
-                                style: Theme.of(context).textTheme.bodySmall
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .bodySmall
                                     ?.copyWith(
                                       color: Theme.of(
                                         context,
@@ -236,4 +242,3 @@ class _LoginPageState extends State<LoginPage> {
     );
   }
 }
-

--- a/lib/src/features/calendar_events/data/remote/calendar_events_firebase_api.dart
+++ b/lib/src/features/calendar_events/data/remote/calendar_events_firebase_api.dart
@@ -14,8 +14,8 @@ class CalendarEventsFirebaseApi extends AbstractCalendarEventsRepository {
   String? get clinicId => OwnerNotifier().clinicId;
 
   /// Reference to the Firestore collection for calendar events
-  final CollectionReference _eventsCollection = FirebaseFirestore.instance
-      .collection('calendar_events');
+  final CollectionReference _eventsCollection =
+      FirebaseFirestore.instance.collection('calendar_events');
 
   /// Firebase Authentication instance
   final FirebaseAuth _auth = FirebaseAuth.instance;
@@ -38,6 +38,9 @@ class CalendarEventsFirebaseApi extends AbstractCalendarEventsRepository {
 
     try {
       final user = _auth.currentUser;
+      if (clinicId == null) {
+        return Left(ServerFailure('No clinic ID found', 403));
+      }
       if (user != null) {
         Query queryRef = _eventsCollection
             .where('clinicId', isEqualTo: clinicId)
@@ -137,6 +140,9 @@ class CalendarEventsFirebaseApi extends AbstractCalendarEventsRepository {
 
     try {
       final user = _auth.currentUser;
+      if (clinicId == null) {
+        return Left(ServerFailure('No clinic ID found', 403));
+      }
       if (user != null) {
         Query queryRef = _eventsCollection
             .where('clinicId', isEqualTo: clinicId)
@@ -180,6 +186,9 @@ class CalendarEventsFirebaseApi extends AbstractCalendarEventsRepository {
 
     try {
       final user = _auth.currentUser;
+      if (clinicId == null) {
+        return Left(ServerFailure('No clinic ID found', 403));
+      }
       if (user != null) {
         final data = event.toJson();
 
@@ -241,8 +250,7 @@ class CalendarEventsFirebaseApi extends AbstractCalendarEventsRepository {
           }
 
           // Check authorization
-          final canEdit =
-              (createdBy == user.uid) ||
+          final canEdit = (createdBy == user.uid) ||
               (OwnerNotifier().hasPermission(AppPermission.editCalendarEvent) &&
                   OwnerNotifier().hasPermission(AppPermission.viewAllSessions));
 
@@ -303,8 +311,7 @@ class CalendarEventsFirebaseApi extends AbstractCalendarEventsRepository {
           final createdBy = data['createdBy']?.toString();
 
           // Check authorization
-          final canDelete =
-              (createdBy == user.uid) ||
+          final canDelete = (createdBy == user.uid) ||
               (OwnerNotifier().hasPermission(
                     AppPermission.deleteCalendarEvent,
                   ) &&
@@ -343,6 +350,9 @@ class CalendarEventsFirebaseApi extends AbstractCalendarEventsRepository {
 
     try {
       final user = _auth.currentUser;
+      if (clinicId == null) {
+        return Left(ServerFailure('No clinic ID found', 403));
+      }
       if (user != null) {
         Query queryRef = _eventsCollection
             .where('clinicId', isEqualTo: clinicId)
@@ -414,6 +424,9 @@ class CalendarEventsFirebaseApi extends AbstractCalendarEventsRepository {
 
     try {
       final user = _auth.currentUser;
+      if (clinicId == null) {
+        return Left(ServerFailure('No clinic ID found', 403));
+      }
       if (user != null) {
         Query queryRef = _eventsCollection
             .where('clinicId', isEqualTo: clinicId)
@@ -508,5 +521,125 @@ class CalendarEventsFirebaseApi extends AbstractCalendarEventsRepository {
       return Left(ServerFailure(e.toString(), 404));
     }
   }
-}
 
+  /// Get all deleted events
+  @override
+  Future<Either<Failure, List<CalendarEventModel>>> getDeletedEvents() async {
+    if (!await _isAuthenticated()) {
+      return Left(ServerFailure('User not authenticated', 401));
+    }
+
+    try {
+      final user = _auth.currentUser;
+      if (clinicId == null) {
+        return Left(ServerFailure('No clinic ID found', 403));
+      }
+      if (user != null) {
+        Query queryRef = _eventsCollection
+            .where('clinicId', isEqualTo: clinicId)
+            .where('deletedAt', isNull: false);
+
+        // Filter by doctorId if user doesn't have viewAllSessions permission
+        if (!OwnerNotifier().hasPermission(AppPermission.viewAllSessions)) {
+          queryRef = queryRef.where('doctorId', isEqualTo: user.uid);
+        }
+
+        final snapshot =
+            await queryRef.orderBy('deletedAt', descending: true).get();
+
+        List<CalendarEventModel> events = snapshot.docs.map((doc) {
+          final data = doc.data() as Map<String, dynamic>?;
+          if (data == null) {
+            throw Exception('Document data is null');
+          }
+          return CalendarEventModel.fromJson({...data, 'id': doc.id});
+        }).toList();
+
+        return Right(events);
+      }
+      return Left(ServerFailure('User not authenticated', 401));
+    } catch (e) {
+      debugPrint('Error getting deleted events: $e');
+      return Left(ServerFailure(e.toString(), 404));
+    }
+  }
+
+  /// Restore a deleted event
+  @override
+  Future<Either<Failure, void>> restoreEvent(String id) async {
+    if (!await _isAuthenticated()) {
+      return Left(ServerFailure('User not authenticated', 401));
+    }
+
+    try {
+      final user = _auth.currentUser;
+      if (user != null) {
+        // Here we might want to check permissions again, similar to update/delete
+        // For simplicity, reusing the logic or just allowing if they can access it?
+        // Let's stick to the pattern: check if they can edit/delete it essentially.
+
+        final doc = await _eventsCollection.doc(id).get();
+        if (!doc.exists) {
+          return Left(ServerFailure('Event does not exist', 404));
+        }
+
+        final data = doc.data() as Map<String, dynamic>?;
+        final createdBy = data?['createdBy']?.toString();
+
+        final canRestore = (createdBy == user.uid) ||
+            (OwnerNotifier().hasPermission(AppPermission.editCalendarEvent) &&
+                OwnerNotifier().hasPermission(AppPermission.viewAllSessions));
+
+        if (canRestore) {
+          await _eventsCollection.doc(id).update({
+            'deletedAt': null,
+            'deletedBy': null,
+          });
+          return Right(null);
+        } else {
+          return Left(ServerFailure('Unauthorized', 403));
+        }
+      }
+      return Left(ServerFailure('User not authenticated', 401));
+    } catch (e) {
+      debugPrint('Error restoring event: $e');
+      return Left(ServerFailure(e.toString(), 404));
+    }
+  }
+
+  /// Permanently delete an event
+  @override
+  Future<Either<Failure, void>> permanentlyDeleteEvent(String id) async {
+    if (!await _isAuthenticated()) {
+      return Left(ServerFailure('User not authenticated', 401));
+    }
+    try {
+      final user = _auth.currentUser;
+      if (user != null) {
+        // Check permissions
+        final doc = await _eventsCollection.doc(id).get();
+        if (!doc.exists) {
+          return Left(ServerFailure('Event does not exist', 404));
+        }
+
+        final data = doc.data() as Map<String, dynamic>?;
+        final createdBy = data?['createdBy']?.toString();
+
+        final canDelete = (createdBy == user.uid) ||
+            (OwnerNotifier().hasPermission(AppPermission.deleteCalendarEvent) &&
+                OwnerNotifier().hasPermission(AppPermission.viewAllSessions));
+
+        if (canDelete) {
+          await _eventsCollection.doc(id).delete();
+          return Right(null);
+        } else {
+          return Left(ServerFailure('Unauthorized', 403));
+        }
+      }
+      return Left(ServerFailure('User not authenticated', 401));
+    } catch (e) {
+      debugPrint('Error permanently deleting event: $e');
+      return Left(ServerFailure(e.toString(), 404));
+    }
+  }
+}

--- a/lib/src/features/calendar_events/data/repositories/calendar_events_repository_impl.dart
+++ b/lib/src/features/calendar_events/data/repositories/calendar_events_repository_impl.dart
@@ -74,5 +74,19 @@ class CalendarEventsRepositoryImpl extends AbstractCalendarEventsRepository {
   ) {
     return firebaseApi.getEventByEvaluationId(evaluationId);
   }
-}
 
+  @override
+  Future<Either<Failure, List<CalendarEventModel>>> getDeletedEvents() {
+    return firebaseApi.getDeletedEvents();
+  }
+
+  @override
+  Future<Either<Failure, void>> restoreEvent(String id) {
+    return firebaseApi.restoreEvent(id);
+  }
+
+  @override
+  Future<Either<Failure, void>> permanentlyDeleteEvent(String id) {
+    return firebaseApi.permanentlyDeleteEvent(id);
+  }
+}

--- a/lib/src/features/calendar_events/domain/models/calendar_event_model.g.dart
+++ b/lib/src/features/calendar_events/domain/models/calendar_event_model.g.dart
@@ -31,29 +31,30 @@ CalendarEventModel _$CalendarEventModelFromJson(Map<String, dynamic> json) =>
       deletedAt: const NullableTimestampConverter().fromJson(json['deletedAt']),
     );
 
-Map<String, dynamic> _$CalendarEventModelToJson(
-  CalendarEventModel instance,
-) => <String, dynamic>{
-  'id': instance.id,
-  'title': instance.title,
-  'startDateTime': const TimestampConverter().toJson(instance.startDateTime),
-  'endDateTime': const TimestampConverter().toJson(instance.endDateTime),
-  'eventType': instance.eventType,
-  'clinicId': instance.clinicId,
-  'createdBy': instance.createdBy,
-  'createdAt': const TimestampConverter().toJson(instance.createdAt),
-  'doctorId': instance.doctorId,
-  'patientId': instance.patientId,
-  'sessionId': instance.sessionId,
-  'evaluationId': instance.evaluationId,
-  'description': instance.description,
-  'location': instance.location,
-  'color': instance.color,
-  'isClinicWide': instance.isClinicWide,
-  'recurrence': instance.recurrence,
-  'updatedBy': instance.updatedBy,
-  'updatedAt': const NullableTimestampConverter().toJson(instance.updatedAt),
-  'deletedBy': instance.deletedBy,
-  'deletedAt': const NullableTimestampConverter().toJson(instance.deletedAt),
-};
-
+Map<String, dynamic> _$CalendarEventModelToJson(CalendarEventModel instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'title': instance.title,
+      'startDateTime':
+          const TimestampConverter().toJson(instance.startDateTime),
+      'endDateTime': const TimestampConverter().toJson(instance.endDateTime),
+      'eventType': instance.eventType,
+      'clinicId': instance.clinicId,
+      'createdBy': instance.createdBy,
+      'createdAt': const TimestampConverter().toJson(instance.createdAt),
+      'doctorId': instance.doctorId,
+      'patientId': instance.patientId,
+      'sessionId': instance.sessionId,
+      'evaluationId': instance.evaluationId,
+      'description': instance.description,
+      'location': instance.location,
+      'color': instance.color,
+      'isClinicWide': instance.isClinicWide,
+      'recurrence': instance.recurrence,
+      'updatedBy': instance.updatedBy,
+      'updatedAt':
+          const NullableTimestampConverter().toJson(instance.updatedAt),
+      'deletedBy': instance.deletedBy,
+      'deletedAt':
+          const NullableTimestampConverter().toJson(instance.deletedAt),
+    };

--- a/lib/src/features/calendar_events/domain/repositories/abstract_calendar_events_repository.dart
+++ b/lib/src/features/calendar_events/domain/repositories/abstract_calendar_events_repository.dart
@@ -68,5 +68,18 @@ abstract class AbstractCalendarEventsRepository {
   Future<Either<Failure, CalendarEventModel?>> getEventByEvaluationId(
     String evaluationId,
   );
-}
 
+  /// Get all deleted events
+  /// Returns list of deleted calendar events or failure
+  Future<Either<Failure, List<CalendarEventModel>>> getDeletedEvents();
+
+  /// Restore a deleted event
+  /// [id] The event ID to restore
+  /// Returns void or failure
+  Future<Either<Failure, void>> restoreEvent(String id);
+
+  /// Permanently delete an event
+  /// [id] The event ID to delete permanently
+  /// Returns void or failure
+  Future<Either<Failure, void>> permanentlyDeleteEvent(String id);
+}

--- a/lib/src/features/clinical_reports/data/remote/clinical_report_firebase_api.dart
+++ b/lib/src/features/clinical_reports/data/remote/clinical_report_firebase_api.dart
@@ -7,6 +7,7 @@ import 'package:dr_copilot/src/core/error/failures.dart';
 import 'package:dr_copilot/src/features/clinical_reports/domain/entities/clinical_report.dart';
 import 'package:dr_copilot/src/features/clinical_reports/domain/models/clinical_report_chat_message.dart';
 import 'package:dr_copilot/src/features/clinical_reports/domain/models/clinical_report_instruction.dart';
+import 'package:dr_copilot/src/features/auth/domain/models/permission_enum.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:flutter/foundation.dart';
@@ -14,8 +15,8 @@ import 'package:http/http.dart' as http;
 import 'package:uuid/uuid.dart';
 
 class ClinicalReportFirebaseApi {
-  final CollectionReference _reportsCollection = FirebaseFirestore.instance
-      .collection('clinical_reports');
+  final CollectionReference _reportsCollection =
+      FirebaseFirestore.instance.collection('clinical_reports');
   final FirebaseStorage _storage = FirebaseStorage.instance;
 
   String? get clinicId => OwnerNotifier().clinicId;
@@ -33,6 +34,21 @@ class ClinicalReportFirebaseApi {
       if (user == null) {
         debugPrint('[saveReport] User not authenticated');
         return Left(ServerFailure('User not authenticated', 401));
+      }
+
+      if (clinicId == null) {
+        return Left(ServerFailure('No clinic ID found', 403));
+      }
+
+      // Check permissions
+      if (report.id == 'new_report_id') {
+        if (!OwnerNotifier().hasPermission(AppPermission.addClinicalReport)) {
+          return Left(ServerFailure('Permission denied', 403));
+        }
+      } else {
+        if (!OwnerNotifier().hasPermission(AppPermission.editClinicalReport)) {
+          return Left(ServerFailure('Permission denied', 403));
+        }
       }
 
       var reportToSave = report;
@@ -111,6 +127,12 @@ class ClinicalReportFirebaseApi {
     String patientId,
   ) async {
     try {
+      if (clinicId == null) {
+        return Left(ServerFailure('No clinic ID found', 403));
+      }
+      if (!OwnerNotifier().hasPermission(AppPermission.viewClinicalReports)) {
+        return Left(ServerFailure('Permission denied', 403));
+      }
       final querySnapshot = await _reportsCollection
           .where('clinicId', isEqualTo: clinicId)
           .where('patientId', isEqualTo: patientId)
@@ -130,6 +152,9 @@ class ClinicalReportFirebaseApi {
   }
 
   Future<Either<Failure, ClinicalReport>> getReportById(String reportId) async {
+    if (!OwnerNotifier().hasPermission(AppPermission.viewClinicalReports)) {
+      return Left(ServerFailure('Permission denied', 403));
+    }
     try {
       final doc = await _reportsCollection.doc(reportId).get();
       if (doc.exists) {
@@ -143,6 +168,12 @@ class ClinicalReportFirebaseApi {
 
   Future<Either<Failure, List<ClinicalReport>>> getAllReports() async {
     try {
+      if (clinicId == null) {
+        return Left(ServerFailure('No clinic ID found', 403));
+      }
+      if (!OwnerNotifier().hasPermission(AppPermission.viewClinicalReports)) {
+        return Left(ServerFailure('Permission denied', 403));
+      }
       final querySnapshot = await _reportsCollection
           .where('clinicId', isEqualTo: clinicId)
           .orderBy('date', descending: true)
@@ -192,6 +223,9 @@ class ClinicalReportFirebaseApi {
   }
 
   Future<Either<Failure, void>> deleteReport(String reportId) async {
+    if (!OwnerNotifier().hasPermission(AppPermission.deleteClinicalReport)) {
+      return Left(ServerFailure('Permission denied', 403));
+    }
     try {
       await _reportsCollection.doc(reportId).delete();
 
@@ -297,7 +331,7 @@ class ClinicalReportFirebaseApi {
   }
 
   Future<Either<Failure, List<ClinicalReportInstruction>>>
-  getInstructions() async {
+      getInstructions() async {
     try {
       final user = FirebaseAuth.instance.currentUser;
       if (user == null) {
@@ -403,4 +437,3 @@ class ClinicalReportFirebaseApi {
     }
   }
 }
-

--- a/lib/src/features/clinical_reports/presentation/pages/create_clinical_report_page.dart
+++ b/lib/src/features/clinical_reports/presentation/pages/create_clinical_report_page.dart
@@ -17,9 +17,8 @@ class CreateClinicalReportPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
-      create: (context) =>
-          getIt<AddEditClinicalReportBloc>()
-            ..add(const LoadAddEditClinicalReport(null)),
+      create: (context) => getIt<AddEditClinicalReportBloc>()
+        ..add(const LoadAddEditClinicalReport(null)),
       child: const CreateClinicalReportView(),
     );
   }
@@ -77,8 +76,8 @@ class _CreateClinicalReportViewState extends State<CreateClinicalReportView> {
       );
 
       context.read<AddEditClinicalReportBloc>().add(
-        SaveClinicalReport(newReport),
-      );
+            SaveClinicalReport(newReport),
+          );
     }
   }
 
@@ -106,50 +105,47 @@ class _CreateClinicalReportViewState extends State<CreateClinicalReportView> {
                         ),
                         onChanged: (value) {
                           context.read<AddEditClinicalReportBloc>().add(
-                            SearchPatients(value),
-                          );
+                                SearchPatients(value),
+                              );
                         },
                       ),
                       const SizedBox(height: 16),
                       Expanded(
-                        child:
-                            BlocBuilder<
-                              AddEditClinicalReportBloc,
-                              AddEditClinicalReportState
-                            >(
-                              builder: (context, state) {
-                                if (state is AddEditClinicalReportLoaded) {
-                                  if (state.patients.isEmpty) {
-                                    return Center(
-                                      child: Text('noPatientsFound'.tr()),
-                                    );
-                                  }
-                                  return ListView.builder(
-                                    shrinkWrap: true,
-                                    itemCount: state.patients.length,
-                                    itemBuilder: (context, index) {
-                                      final patient = state.patients[index];
-                                      return ListTile(
-                                        title: Text(patient.name),
-                                        subtitle: Text(
-                                          patient.phoneNumber ??
-                                              'noPhoneNumber'.tr(),
-                                        ),
-                                        onTap: () {
-                                          this.setState(() {
-                                            _selectedPatient = patient;
-                                          });
-                                          Navigator.of(context).pop();
-                                        },
-                                      );
+                        child: BlocBuilder<AddEditClinicalReportBloc,
+                            AddEditClinicalReportState>(
+                          builder: (context, state) {
+                            if (state is AddEditClinicalReportLoaded) {
+                              if (state.patients.isEmpty) {
+                                return Center(
+                                  child: Text('noPatientsFound'.tr()),
+                                );
+                              }
+                              return ListView.builder(
+                                shrinkWrap: true,
+                                itemCount: state.patients.length,
+                                itemBuilder: (context, index) {
+                                  final patient = state.patients[index];
+                                  return ListTile(
+                                    title: Text(patient.name),
+                                    subtitle: Text(
+                                      patient.phoneNumber ??
+                                          'noPhoneNumber'.tr(),
+                                    ),
+                                    onTap: () {
+                                      this.setState(() {
+                                        _selectedPatient = patient;
+                                      });
+                                      Navigator.of(context).pop();
                                     },
                                   );
-                                }
-                                return const Center(
-                                  child: CircularProgressIndicator(),
-                                );
-                              },
-                            ),
+                                },
+                              );
+                            }
+                            return const Center(
+                              child: CircularProgressIndicator(),
+                            );
+                          },
+                        ),
                       ),
                     ],
                   ),
@@ -192,147 +188,146 @@ class _CreateClinicalReportViewState extends State<CreateClinicalReportView> {
         appBar: AppBar(title: Text('createClinicalReport'.tr())),
         body:
             BlocBuilder<AddEditClinicalReportBloc, AddEditClinicalReportState>(
-              builder: (context, state) {
-                if (state is AddEditClinicalReportLoading) {
-                  return const Center(child: CircularProgressIndicator());
-                }
+          builder: (context, state) {
+            if (state is AddEditClinicalReportLoading) {
+              return const Center(child: CircularProgressIndicator());
+            }
 
-                if (state is AddEditClinicalReportLoaded) {
-                  return Padding(
-                    padding: const EdgeInsets.all(24.0),
-                    child: Form(
-                      key: _formKey,
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            'patient'.tr(),
-                            style: Theme.of(context).textTheme.titleMedium,
+            if (state is AddEditClinicalReportLoaded) {
+              return Padding(
+                padding: const EdgeInsets.all(24.0),
+                child: Form(
+                  key: _formKey,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'patient'.tr(),
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                      const SizedBox(height: 8),
+                      InkWell(
+                        onTap: () => _showPatientSelectionDialog(context),
+                        borderRadius: BorderRadius.circular(8),
+                        child: Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 16,
+                            vertical: 16,
                           ),
-                          const SizedBox(height: 8),
-                          InkWell(
-                            onTap: () => _showPatientSelectionDialog(context),
+                          decoration: BoxDecoration(
+                            border: Border.all(color: Colors.grey.shade400),
                             borderRadius: BorderRadius.circular(8),
-                            child: Container(
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 16,
-                                vertical: 16,
-                              ),
-                              decoration: BoxDecoration(
-                                border: Border.all(color: Colors.grey.shade400),
-                                borderRadius: BorderRadius.circular(8),
-                              ),
-                              child: Row(
-                                children: [
-                                  Icon(
-                                    Icons.person_outline,
-                                    color: Colors.grey.shade600,
-                                  ),
-                                  const SizedBox(width: 16),
-                                  Expanded(
-                                    child: Text(
-                                      _selectedPatient?.name ??
-                                          'selectPatient'.tr(),
-                                      style: TextStyle(
-                                        fontSize: 16,
-                                        color: _selectedPatient == null
-                                            ? Colors.grey.shade600
-                                            : Theme.of(
-                                                context,
-                                              ).colorScheme.onSurface,
-                                      ),
-                                    ),
-                                  ),
-                                  const Icon(Icons.arrow_drop_down),
-                                ],
-                              ),
-                            ),
                           ),
-                          const SizedBox(height: 24),
-                          Text(
-                            'clinicalReportTitle'.tr(),
-                            style: Theme.of(context).textTheme.titleMedium,
-                          ),
-                          const SizedBox(height: 8),
-                          TextFormField(
-                            controller: _titleController,
-                            decoration: InputDecoration(
-                              hintText: 'clinicalReportTitle'.tr(),
-                              border: OutlineInputBorder(
-                                borderRadius: BorderRadius.circular(8),
+                          child: Row(
+                            children: [
+                              Icon(
+                                Icons.person_outline,
+                                color: Colors.grey.shade600,
                               ),
-                              prefixIcon: const Icon(Icons.title),
-                            ),
-                          ),
-                          const SizedBox(height: 24),
-                          Text(
-                            'clinicalReportDate'.tr(),
-                            style: Theme.of(context).textTheme.titleMedium,
-                          ),
-                          const SizedBox(height: 8),
-                          Container(
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: 16,
-                              vertical: 16,
-                            ),
-                            decoration: BoxDecoration(
-                              color: Colors.grey.shade100,
-                              border: Border.all(color: Colors.grey.shade300),
-                              borderRadius: BorderRadius.circular(8),
-                            ),
-                            child: Row(
-                              children: [
-                                Icon(
-                                  Icons.calendar_today,
-                                  color: Colors.grey.shade600,
-                                ),
-                                const SizedBox(width: 16),
-                                Text(
-                                  DateFormat.yMMMd().add_jm().format(
-                                    _selectedDate,
-                                  ),
+                              const SizedBox(width: 16),
+                              Expanded(
+                                child: Text(
+                                  _selectedPatient?.name ??
+                                      'selectPatient'.tr(),
                                   style: TextStyle(
                                     fontSize: 16,
-                                    color: Colors.grey.shade700,
+                                    color: _selectedPatient == null
+                                        ? Colors.grey.shade600
+                                        : Theme.of(
+                                            context,
+                                          ).colorScheme.onSurface,
                                   ),
                                 ),
-                                const Spacer(),
-                                const Icon(
-                                  Icons.lock_outline,
-                                  size: 16,
-                                  color: Colors.grey,
-                                ),
-                              ],
-                            ),
-                          ),
-                          const Spacer(),
-                          SizedBox(
-                            width: double.infinity,
-                            height: 50,
-                            child: ElevatedButton(
-                              onPressed: _createClinicalReport,
-                              style: ElevatedButton.styleFrom(
-                                shape: RoundedRectangleBorder(
-                                  borderRadius: BorderRadius.circular(8),
-                                ),
                               ),
-                              child: Text(
-                                'createReport'.tr(),
-                                style: const TextStyle(fontSize: 16),
-                              ),
-                            ),
+                              const Icon(Icons.arrow_drop_down),
+                            ],
                           ),
-                        ],
+                        ),
                       ),
-                    ),
-                  );
-                }
+                      const SizedBox(height: 24),
+                      Text(
+                        'clinicalReportTitle'.tr(),
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                      const SizedBox(height: 8),
+                      TextFormField(
+                        controller: _titleController,
+                        decoration: InputDecoration(
+                          hintText: 'clinicalReportTitle'.tr(),
+                          border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          prefixIcon: const Icon(Icons.title),
+                        ),
+                      ),
+                      const SizedBox(height: 24),
+                      Text(
+                        'clinicalReportDate'.tr(),
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                      const SizedBox(height: 8),
+                      Container(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 16,
+                          vertical: 16,
+                        ),
+                        decoration: BoxDecoration(
+                          color: Colors.grey.shade100,
+                          border: Border.all(color: Colors.grey.shade300),
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: Row(
+                          children: [
+                            Icon(
+                              Icons.calendar_today_outlined,
+                              color: Colors.grey.shade600,
+                            ),
+                            const SizedBox(width: 16),
+                            Text(
+                              DateFormat.yMMMd().add_jm().format(
+                                    _selectedDate,
+                                  ),
+                              style: TextStyle(
+                                fontSize: 16,
+                                color: Colors.grey.shade700,
+                              ),
+                            ),
+                            const Spacer(),
+                            const Icon(
+                              Icons.lock_outline,
+                              size: 16,
+                              color: Colors.grey,
+                            ),
+                          ],
+                        ),
+                      ),
+                      const Spacer(),
+                      SizedBox(
+                        width: double.infinity,
+                        height: 50,
+                        child: ElevatedButton(
+                          onPressed: _createClinicalReport,
+                          style: ElevatedButton.styleFrom(
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(8),
+                            ),
+                          ),
+                          child: Text(
+                            'createReport'.tr(),
+                            style: const TextStyle(fontSize: 16),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              );
+            }
 
-                return Center(child: Text('somethingWentWrong'.tr()));
-              },
-            ),
+            return Center(child: Text('somethingWentWrong'.tr()));
+          },
+        ),
       ),
     );
   }
 }
-

--- a/lib/src/features/clinical_reports/presentation/widgets/ai_chat_panel.dart
+++ b/lib/src/features/clinical_reports/presentation/widgets/ai_chat_panel.dart
@@ -84,7 +84,7 @@ class _AIChatPanelState extends State<AIChatPanel> {
                         shape: BoxShape.circle,
                       ),
                       child: Icon(
-                        Icons.auto_awesome,
+                        Icons.auto_awesome_outlined,
                         color: Theme.of(context).primaryColor,
                         size: 20,
                       ),
@@ -114,46 +114,43 @@ class _AIChatPanelState extends State<AIChatPanel> {
 
           // Content
           Expanded(
-            child:
-                BlocBuilder<
-                  AddEditClinicalReportBloc,
-                  AddEditClinicalReportState
-                >(
-                  builder: (context, state) {
-                    if (state is AddEditClinicalReportLoaded) {
-                      if (state.isAILoading) {
-                        return const Center(child: CircularProgressIndicator());
-                      }
+            child: BlocBuilder<AddEditClinicalReportBloc,
+                AddEditClinicalReportState>(
+              builder: (context, state) {
+                if (state is AddEditClinicalReportLoaded) {
+                  if (state.isAILoading) {
+                    return const Center(child: CircularProgressIndicator());
+                  }
 
-                      if (state.isReviewingAIChanges) {
-                        return _buildReviewUI(context);
-                      }
+                  if (state.isReviewingAIChanges) {
+                    return _buildReviewUI(context);
+                  }
 
-                      return DefaultTabController(
-                        length: 2,
-                        child: Column(
-                          children: [
-                            const TabBar(
-                              tabs: [
-                                Tab(text: 'Edit'),
-                                Tab(text: 'Chat'),
-                              ],
-                            ),
-                            Expanded(
-                              child: TabBarView(
-                                children: [
-                                  _buildEditTab(context, state),
-                                  _buildChatTab(context, state),
-                                ],
-                              ),
-                            ),
+                  return DefaultTabController(
+                    length: 2,
+                    child: Column(
+                      children: [
+                        const TabBar(
+                          tabs: [
+                            Tab(text: 'Edit'),
+                            Tab(text: 'Chat'),
                           ],
                         ),
-                      );
-                    }
-                    return const SizedBox.shrink();
-                  },
-                ),
+                        Expanded(
+                          child: TabBarView(
+                            children: [
+                              _buildEditTab(context, state),
+                              _buildChatTab(context, state),
+                            ],
+                          ),
+                        ),
+                      ],
+                    ),
+                  );
+                }
+                return const SizedBox.shrink();
+              },
+            ),
           ),
         ],
       ),
@@ -185,8 +182,8 @@ class _AIChatPanelState extends State<AIChatPanel> {
                 child: OutlinedButton(
                   onPressed: () {
                     context.read<AddEditClinicalReportBloc>().add(
-                      AIEditRejected(),
-                    );
+                          AIEditRejected(),
+                        );
                   },
                   child: const Text('Reject'),
                 ),
@@ -196,8 +193,8 @@ class _AIChatPanelState extends State<AIChatPanel> {
                 child: ElevatedButton(
                   onPressed: () {
                     context.read<AddEditClinicalReportBloc>().add(
-                      AIEditAccepted(),
-                    );
+                          AIEditAccepted(),
+                        );
                   },
                   child: const Text('Accept'),
                 ),
@@ -392,7 +389,7 @@ class _AIChatPanelState extends State<AIChatPanel> {
                 Row(
                   children: [
                     Icon(
-                      Icons.auto_awesome,
+                      Icons.auto_awesome_outlined,
                       size: 16,
                       color: Theme.of(context).primaryColor,
                     ),
@@ -503,9 +500,8 @@ class _AIChatPanelState extends State<AIChatPanel> {
                     final message = state.chatMessages[index];
                     final isUser = message.sender == ChatMessageSender.user;
                     return Align(
-                      alignment: isUser
-                          ? Alignment.centerRight
-                          : Alignment.centerLeft,
+                      alignment:
+                          isUser ? Alignment.centerRight : Alignment.centerLeft,
                       child: Container(
                         constraints: BoxConstraints(
                           maxWidth: MediaQuery.of(context).size.width * 0.7,
@@ -582,8 +578,8 @@ class _AIChatPanelState extends State<AIChatPanel> {
                     onSubmitted: (value) {
                       if (value.isNotEmpty && state.report != null) {
                         context.read<AddEditClinicalReportBloc>().add(
-                          SendChatMessage(state.report!.id, value),
-                        );
+                              SendChatMessage(state.report!.id, value),
+                            );
                         chatController.clear();
                       }
                     },
@@ -602,8 +598,9 @@ class _AIChatPanelState extends State<AIChatPanel> {
                     if (chatController.text.isNotEmpty &&
                         state.report != null) {
                       context.read<AddEditClinicalReportBloc>().add(
-                        SendChatMessage(state.report!.id, chatController.text),
-                      );
+                            SendChatMessage(
+                                state.report!.id, chatController.text),
+                          );
                       chatController.clear();
                     }
                   },
@@ -663,4 +660,3 @@ class _AIChatPanelState extends State<AIChatPanel> {
     );
   }
 }
-

--- a/lib/src/features/copilot_chat/domain/models/copilot_model.g.dart
+++ b/lib/src/features/copilot_chat/domain/models/copilot_model.g.dart
@@ -7,10 +7,10 @@ part of 'copilot_model.dart';
 // **************************************************************************
 
 CopilotModel _$CopilotModelFromJson(Map<String, dynamic> json) => CopilotModel(
-  id: json['id'] as String,
-  name: json['name'] as String,
-  role: json['role'] as String,
-);
+      id: json['id'] as String,
+      name: json['name'] as String,
+      role: json['role'] as String,
+    );
 
 Map<String, dynamic> _$CopilotModelToJson(CopilotModel instance) =>
     <String, dynamic>{
@@ -18,4 +18,3 @@ Map<String, dynamic> _$CopilotModelToJson(CopilotModel instance) =>
       'name': instance.name,
       'role': instance.role,
     };
-

--- a/lib/src/features/copilot_chat/presentation/bloc/copilot_bloc.dart
+++ b/lib/src/features/copilot_chat/presentation/bloc/copilot_bloc.dart
@@ -1,9 +1,7 @@
 import 'dart:convert';
-import 'dart:typed_data';
 
 import 'package:bloc/bloc.dart';
 import 'package:dr_copilot/src/core/error/failures.dart';
-import 'package:dr_copilot/src/features/copilot_chat/domain/services/ai_service_interface.dart';
 import 'package:dr_copilot/src/features/copilot_chat/services/claude_service.dart';
 import 'package:dr_copilot/src/features/copilot_chat/services/deepseek_service.dart';
 import 'package:dr_copilot/src/features/copilot_chat/services/gemini_service.dart';

--- a/lib/src/features/copilot_chat/presentation/pages/copilot_page.dart
+++ b/lib/src/features/copilot_chat/presentation/pages/copilot_page.dart
@@ -70,8 +70,6 @@ class _CopilotPageState extends State<CopilotPage> {
   String? _currentConversationId;
   bool _isSidebarVisible = false; // Sidebar hidden by default
 
-  String _selectedModel = 'Gemini';
-  final bool _isModelChoiceEnabled = true;
   Uint8List? _pickedImage;
 
   final List<String> _availableModels = [];
@@ -106,7 +104,8 @@ class _CopilotPageState extends State<CopilotPage> {
     try {
       final ownerNotifier = Provider.of<OwnerNotifier>(context, listen: false);
       String? clinicId = ownerNotifier.clinicId;
-      final user = await sl<AbstractAuthRepository>().getCurrentUser();
+      final userResult = await sl<AbstractAuthRepository>().getCurrentUser();
+      final user = userResult.fold((l) => null, (r) => r);
 
       if (clinicId == null && user != null) {
         final userDoc = await FirebaseFirestore.instance
@@ -145,7 +144,8 @@ class _CopilotPageState extends State<CopilotPage> {
     try {
       final ownerNotifier = Provider.of<OwnerNotifier>(context, listen: false);
       final clinicId = ownerNotifier.clinicId;
-      final user = await sl<AbstractAuthRepository>().getCurrentUser();
+      final userResult = await sl<AbstractAuthRepository>().getCurrentUser();
+      final user = userResult.fold((l) => null, (r) => r);
 
       debugPrint(
           '[CopilotPage] Loading permissions - clinicId: $clinicId, userId: ${user?.uid}');

--- a/lib/src/features/copilot_chat/presentation/widgets/copilot_view.dart
+++ b/lib/src/features/copilot_chat/presentation/widgets/copilot_view.dart
@@ -77,7 +77,7 @@ class CopilotView extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         title: Text('copilotChat'.tr()),
-        leading: const Icon(Icons.chat),
+        leading: const Icon(Icons.chat_outlined),
         actions: [
           IconButton(
             icon: const Icon(Icons.history),
@@ -236,7 +236,7 @@ class CopilotView extends StatelessWidget {
                                                         padding:
                                                             EdgeInsets.all(2.0),
                                                         child: Icon(
-                                                          Icons.cancel,
+                                                          Icons.cancel_outlined,
                                                           color: Colors.red,
                                                           size: 20,
                                                         ),

--- a/lib/src/features/copilot_chat/presentation/widgets/empty_chat_placeholder.dart
+++ b/lib/src/features/copilot_chat/presentation/widgets/empty_chat_placeholder.dart
@@ -80,10 +80,12 @@ class EmptyChatPlaceholder extends StatelessWidget {
     if (canManagePatients) capabilities.add('Manage Patients 👥');
     if (canManageSessions) capabilities.add('Schedule Sessions 📅');
     if (canManageEvals) capabilities.add('Track Evaluations 📊');
-    if (permissions.contains('can_view_analytics'))
+    if (permissions.contains('can_view_analytics')) {
       capabilities.add('Analyze Clinic Data 📈');
-    if (permissions.contains('can_view_financials'))
+    }
+    if (permissions.contains('can_view_financials')) {
       capabilities.add('Check Financials 💰');
+    }
 
     if (capabilities.isEmpty) return const SizedBox.shrink();
 

--- a/lib/src/features/copilot_chat/services/gemini_tools.dart
+++ b/lib/src/features/copilot_chat/services/gemini_tools.dart
@@ -71,8 +71,9 @@ List<Tool> getGeminiTools({List<String> userRequiredFields = const []}) {
     patientRequired.add('phoneNumber');
   }
   if (isRequired('patient', 'address')) patientRequired.add('address');
-  if (isRequired('patient', 'alt_phone'))
+  if (isRequired('patient', 'alt_phone')) {
     patientRequired.add('alternativePhoneNumber');
+  }
   if (isRequired('patient', 'doctor')) patientRequired.add('treatingDoctor');
   if (isRequired('patient', 'occupation')) patientRequired.add('occupation');
 

--- a/lib/src/features/copilot_chat/utils/ai_context_provider.dart
+++ b/lib/src/features/copilot_chat/utils/ai_context_provider.dart
@@ -73,7 +73,7 @@ class AIContextProvider {
     2. CHECK PARAMETERS: Compare user input against the function's parameters.
     3. SMART BATCHING: 
 $batchingInstructions
-       - Example: "I can help with that. Could you provide the patient's name${readableFields.isNotEmpty ? ', ' + readableFields.join(', ') : ', age, and phone number'}?"
+       - Example: "I can help with that. Could you provide the patient's name${readableFields.isNotEmpty ? ', ${readableFields.join(', ')}' : ', age, and phone number'}?"
     
     4. NO NAG: If the user provides just the Name and says "Skip the rest" or implies they are done, execute the function immediately. Do not insist on optional fields.
     

--- a/lib/src/features/doctors/data/remote/doctor_firebase_api.dart
+++ b/lib/src/features/doctors/data/remote/doctor_firebase_api.dart
@@ -1,11 +1,16 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:dr_copilot/src/core/error/exceptions.dart';
 import 'package:dr_copilot/src/features/doctors/domain/models/doctor_model.dart';
+import 'package:dr_copilot/src/core/app/notifiers/owner_notifier.dart';
+import 'package:dr_copilot/src/features/auth/domain/models/permission_enum.dart';
 
 class DoctorFirebaseApi {
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
 
   Future<void> addDoctor(DoctorModel doctor) async {
+    if (!OwnerNotifier().hasPermission(AppPermission.manageDoctors)) {
+      throw ServerException('Permission denied', 403);
+    }
     try {
       await _firestore
           .collection('doctors')
@@ -17,6 +22,9 @@ class DoctorFirebaseApi {
   }
 
   Future<DoctorModel> getDoctor(String doctorId) async {
+    if (!OwnerNotifier().hasPermission(AppPermission.viewDoctors)) {
+      throw ServerException('Permission denied', 403);
+    }
     try {
       final doc = await _firestore.collection('doctors').doc(doctorId).get();
       if (!doc.exists) {
@@ -29,6 +37,9 @@ class DoctorFirebaseApi {
   }
 
   Future<List<DoctorModel>> getDoctors({String? clinicId}) async {
+    if (!OwnerNotifier().hasPermission(AppPermission.viewDoctors)) {
+      throw ServerException('Permission denied', 403);
+    }
     try {
       Query query = _firestore.collection('doctors');
       if (clinicId != null) {
@@ -42,6 +53,9 @@ class DoctorFirebaseApi {
   }
 
   Future<void> updateDoctor(String doctorId, DoctorModel doctor) async {
+    if (!OwnerNotifier().hasPermission(AppPermission.manageDoctors)) {
+      throw ServerException('Permission denied', 403);
+    }
     try {
       await _firestore
           .collection('doctors')
@@ -53,6 +67,9 @@ class DoctorFirebaseApi {
   }
 
   Future<void> deleteDoctor(String doctorId) async {
+    if (!OwnerNotifier().hasPermission(AppPermission.manageDoctors)) {
+      throw ServerException('Permission denied', 403);
+    }
     try {
       await _firestore.collection('doctors').doc(doctorId).delete();
     } catch (e) {
@@ -60,4 +77,3 @@ class DoctorFirebaseApi {
     }
   }
 }
-

--- a/lib/src/features/doctors/presentation/bloc/doctors_bloc.dart
+++ b/lib/src/features/doctors/presentation/bloc/doctors_bloc.dart
@@ -22,8 +22,8 @@ class DoctorsBloc extends Bloc<DoctorsEvent, DoctorsState> {
     emit(DoctorsLoading(state.doctors));
     final failureOrSuccess = await _doctorsUseCase.addDoctor(event.doctor);
     failureOrSuccess.fold(
-      (failure) =>
-          DoctorsError(state.doctors, message: _mapFailureToMessage(failure)),
+      (failure) => emit(
+          DoctorsError(state.doctors, message: _mapFailureToMessage(failure))),
       (_) {
         final updatedDoctors = List<DoctorModel>.from(state.doctors)
           ..add(event.doctor);
@@ -39,8 +39,8 @@ class DoctorsBloc extends Bloc<DoctorsEvent, DoctorsState> {
     final failureOrDoctors =
         await _doctorsUseCase.getDoctors(clinicId: event.clinicId);
     failureOrDoctors.fold(
-      (failure) =>
-          DoctorsError(state.doctors, message: _mapFailureToMessage(failure)),
+      (failure) => emit(
+          DoctorsError(state.doctors, message: _mapFailureToMessage(failure))),
       (doctors) => emit(DoctorsLoaded(doctors)),
     );
   }
@@ -50,8 +50,8 @@ class DoctorsBloc extends Bloc<DoctorsEvent, DoctorsState> {
     final failureOrSuccess =
         await _doctorsUseCase.updateDoctor(event.doctorId, event.doctor);
     failureOrSuccess.fold(
-      (failure) =>
-          DoctorsError(state.doctors, message: _mapFailureToMessage(failure)),
+      (failure) => emit(
+          DoctorsError(state.doctors, message: _mapFailureToMessage(failure))),
       (_) {
         final updatedDoctors = state.doctors.map((doctor) {
           return doctor.id == event.doctorId ? event.doctor : doctor;
@@ -67,8 +67,8 @@ class DoctorsBloc extends Bloc<DoctorsEvent, DoctorsState> {
     emit(DoctorsLoading(state.doctors));
     final failureOrSuccess = await _doctorsUseCase.deleteDoctor(event.doctorId);
     failureOrSuccess.fold(
-      (failure) =>
-          DoctorsError(state.doctors, message: _mapFailureToMessage(failure)),
+      (failure) => emit(
+          DoctorsError(state.doctors, message: _mapFailureToMessage(failure))),
       (_) {
         final updatedDoctors = state.doctors
             .where((doctor) => doctor.id != event.doctorId)
@@ -91,4 +91,3 @@ class DoctorsBloc extends Bloc<DoctorsEvent, DoctorsState> {
     }
   }
 }
-

--- a/lib/src/features/doctors/presentation/pages/doctors_page.dart
+++ b/lib/src/features/doctors/presentation/pages/doctors_page.dart
@@ -1,3 +1,4 @@
+import 'package:dr_copilot/src/core/app/notifiers/owner_notifier.dart';
 import 'package:dr_copilot/src/features/doctors/presentation/bloc/doctors_bloc.dart';
 import 'package:dr_copilot/src/features/doctors/presentation/widgets/doctor_list_item.dart';
 import 'package:easy_localization/easy_localization.dart';
@@ -14,10 +15,35 @@ class DoctorsPage extends StatefulWidget {
 }
 
 class _DoctorsPageState extends State<DoctorsPage> {
+  String? _currentClinicId;
+  late final OwnerNotifier _ownerNotifier;
+
   @override
   void initState() {
     super.initState();
-    context.read<DoctorsBloc>().add(const GetDoctors());
+    _ownerNotifier = context.read<OwnerNotifier>();
+    final clinicId = _ownerNotifier.clinicId;
+    if (clinicId != null) {
+      _currentClinicId = clinicId;
+      context.read<DoctorsBloc>().add(GetDoctors(clinicId: clinicId));
+    }
+    _ownerNotifier.addListener(_onClinicChanged);
+  }
+
+  void _onClinicChanged() {
+    final clinicId = _ownerNotifier.clinicId;
+    if (clinicId != null && clinicId != _currentClinicId) {
+      setState(() {
+        _currentClinicId = clinicId;
+      });
+      context.read<DoctorsBloc>().add(GetDoctors(clinicId: clinicId));
+    }
+  }
+
+  @override
+  void dispose() {
+    _ownerNotifier.removeListener(_onClinicChanged);
+    super.dispose();
   }
 
   @override
@@ -75,4 +101,3 @@ class _DoctorsPageState extends State<DoctorsPage> {
     );
   }
 }
-

--- a/lib/src/features/financials/data/remote/financials_firebase_api.dart
+++ b/lib/src/features/financials/data/remote/financials_firebase_api.dart
@@ -1,4 +1,5 @@
 import 'package:dr_copilot/src/core/app/notifiers/owner_notifier.dart';
+import 'package:dr_copilot/src/features/auth/domain/models/permission_enum.dart';
 import 'package:dr_copilot/src/features/financials/data/remote/abstract_financial_api.dart';
 import 'package:dr_copilot/src/features/financials/transactions/domain/models/transaction_model.dart';
 import 'package:dr_copilot/src/features/appointments/sessions/domain/usecases/sessions_usecase.dart';
@@ -20,6 +21,9 @@ import 'package:dr_copilot/src/features/financials/domain/models/invoice_model.d
 class FinancialsFirebaseApi extends AbstractFinancialApi {
   // --- Transactions CRUD ---
   final TransactionsUseCase transactionsUseCase;
+
+  /// The clinic ID of the user, fetched from OwnerNotifier.
+  String? get clinicId => OwnerNotifier().clinicId;
 
   /// The owner ID of the user, fetched from Firebase Auth.
   String? get ownerId => OwnerNotifier().ownerId;
@@ -49,15 +53,32 @@ class FinancialsFirebaseApi extends AbstractFinancialApi {
   @override
   Future<Either<Failure, void>> deleteTransactionByReferenceId(
       String referenceId) async {
-    return await transactionsUseCase
-        .deleteTransactionByReferenceId(referenceId);
+    if (clinicId == null) {
+      return Left(ServerFailure(
+          'No clinic ID found. Please ensure you are assigned to a clinic.',
+          403));
+    }
+    if (!OwnerNotifier().hasPermission(AppPermission.deleteFinancialEntry)) {
+      return Left(ServerFailure('Permission denied', 403));
+    }
+    return await transactionsUseCase.deleteTransactionByReferenceId(
+        clinicId!, referenceId);
   }
 
   // Fetch all transactions
   @override
   Future<Either<Failure, List<TransactionModel>>> fetchTransactions(
       {String? lastDocumentId, int? limit = 20}) async {
+    if (clinicId == null) {
+      return Left(ServerFailure(
+          'No clinic ID found. Please ensure you are assigned to a clinic.',
+          403));
+    }
+    if (!OwnerNotifier().hasPermission(AppPermission.viewFinancials)) {
+      return Left(ServerFailure('Permission denied', 403));
+    }
     return await transactionsUseCase.getTransactions(
+      clinicId: clinicId!,
       lastDocumentId: lastDocumentId,
       limit: limit,
     );
@@ -67,6 +88,9 @@ class FinancialsFirebaseApi extends AbstractFinancialApi {
   @override
   Future<Either<Failure, InvoiceModel>> addInvoice(
       {required InvoiceModel invoice}) async {
+    if (!OwnerNotifier().hasPermission(AppPermission.addFinancialEntry)) {
+      return Left(ServerFailure('Permission denied', 403));
+    }
     try {
       final user = FirebaseAuth.instance.currentUser;
       if (user != null) {
@@ -88,6 +112,9 @@ class FinancialsFirebaseApi extends AbstractFinancialApi {
   @override
   Future<Either<Failure, InvoiceModel>> updateInvoice(
       {required InvoiceModel invoice}) async {
+    if (!OwnerNotifier().hasPermission(AppPermission.editFinancialEntry)) {
+      return Left(ServerFailure('Permission denied', 403));
+    }
     try {
       final user = FirebaseAuth.instance.currentUser;
       if (user != null) {
@@ -107,11 +134,19 @@ class FinancialsFirebaseApi extends AbstractFinancialApi {
   @override
   Future<Either<Failure, List<InvoiceModel>>> fetchInvoices() async {
     try {
+      if (clinicId == null) {
+        return Left(ServerFailure(
+            'No clinic ID found. Please ensure you are assigned to a clinic.',
+            403));
+      }
+      if (!OwnerNotifier().hasPermission(AppPermission.viewFinancials)) {
+        return Left(ServerFailure('Permission denied', 403));
+      }
       final user = FirebaseAuth.instance.currentUser;
       if (user != null) {
         final snapshot = await FirebaseFirestore.instance
             .collection('invoices')
-            .where('ownerId', isEqualTo: ownerId)
+            .where('clinicId', isEqualTo: clinicId)
             .get();
         final invoices = snapshot.docs.map((doc) {
           final data = doc.data();
@@ -136,6 +171,9 @@ class FinancialsFirebaseApi extends AbstractFinancialApi {
 
   @override
   Future<Either<Failure, void>> deleteInvoice(String id) async {
+    if (!OwnerNotifier().hasPermission(AppPermission.deleteFinancialEntry)) {
+      return Left(ServerFailure('Permission denied', 403));
+    }
     try {
       final user = FirebaseAuth.instance.currentUser;
       if (user != null) {
@@ -156,6 +194,9 @@ class FinancialsFirebaseApi extends AbstractFinancialApi {
   @override
   Future<Either<Failure, InvoiceModel>> deleteInvoiceByReferenceId(
       String referenceId) async {
+    if (!OwnerNotifier().hasPermission(AppPermission.deleteFinancialEntry)) {
+      return Left(ServerFailure('Permission denied', 403));
+    }
     try {
       final user = FirebaseAuth.instance.currentUser;
       if (user != null) {
@@ -181,6 +222,9 @@ class FinancialsFirebaseApi extends AbstractFinancialApi {
   // --- Bill CRUD ---
   @override
   Future<Either<Failure, BillModel>> addBill({required BillModel bill}) async {
+    if (!OwnerNotifier().hasPermission(AppPermission.addFinancialEntry)) {
+      return Left(ServerFailure('Permission denied', 403));
+    }
     try {
       final user = FirebaseAuth.instance.currentUser;
       if (user != null) {
@@ -201,6 +245,9 @@ class FinancialsFirebaseApi extends AbstractFinancialApi {
   @override
   Future<Either<Failure, BillModel>> updateBill(
       {required BillModel bill}) async {
+    if (!OwnerNotifier().hasPermission(AppPermission.editFinancialEntry)) {
+      return Left(ServerFailure('Permission denied', 403));
+    }
     try {
       final user = FirebaseAuth.instance.currentUser;
       if (user != null) {
@@ -220,11 +267,19 @@ class FinancialsFirebaseApi extends AbstractFinancialApi {
   @override
   Future<Either<Failure, List<BillModel>>> fetchBills() async {
     try {
+      if (clinicId == null) {
+        return Left(ServerFailure(
+            'No clinic ID found. Please ensure you are assigned to a clinic.',
+            403));
+      }
+      if (!OwnerNotifier().hasPermission(AppPermission.viewFinancials)) {
+        return Left(ServerFailure('Permission denied', 403));
+      }
       final user = FirebaseAuth.instance.currentUser;
       if (user != null) {
         final snapshot = await FirebaseFirestore.instance
             .collection('bills')
-            .where('ownerId', isEqualTo: ownerId)
+            .where('clinicId', isEqualTo: clinicId)
             .get();
         final bills = snapshot.docs.map((doc) {
           final data = doc.data();
@@ -248,6 +303,9 @@ class FinancialsFirebaseApi extends AbstractFinancialApi {
 
   @override
   Future<Either<Failure, void>> deleteBill(String id) async {
+    if (!OwnerNotifier().hasPermission(AppPermission.deleteFinancialEntry)) {
+      return Left(ServerFailure('Permission denied', 403));
+    }
     try {
       final user = FirebaseAuth.instance.currentUser;
       if (user != null) {
@@ -702,4 +760,3 @@ class FinancialsFirebaseApi extends AbstractFinancialApi {
     }
   }
 }
-

--- a/lib/src/features/financials/domain/models/bill_model.g.dart
+++ b/lib/src/features/financials/domain/models/bill_model.g.dart
@@ -7,51 +7,50 @@ part of 'bill_model.dart';
 // **************************************************************************
 
 BillModel _$BillModelFromJson(Map<String, dynamic> json) => BillModel(
-  id: json['id'] as String,
-  ownerId: json['ownerId'] as String,
-  clinicId: json['clinicId'] as String,
-  scheduledBillId: json['scheduledBillId'] as String?,
-  title: json['title'] as String,
-  description: json['description'] as String,
-  amount: (json['amount'] as num).toDouble(),
-  currencyProfileId: json['currencyProfileId'] as String,
-  dueDate: const TimestampConverter().fromJson(json['dueDate']),
-  status:
-      $enumDecodeNullable(_$BillStatusEnumMap, json['status']) ??
-      BillStatus.unpaid,
-  paymentMethod: $enumDecodeNullable(
-    _$PaymentMethodEnumMap,
-    json['paymentMethod'],
-  ),
-  payedAt: const NullableTimestampConverter().fromJson(json['payedAt']),
-  createdAt: const TimestampConverter().fromJson(json['createdAt']),
-  updatedAt: const NullableTimestampConverter().fromJson(json['updatedAt']),
-  deletedAt: const NullableTimestampConverter().fromJson(json['deletedAt']),
-  createdBy: json['createdBy'] as String,
-  updatedBy: json['updatedBy'] as String?,
-  deletedBy: json['deletedBy'] as String?,
-);
+      id: json['id'] as String,
+      ownerId: json['ownerId'] as String,
+      clinicId: json['clinicId'] as String,
+      scheduledBillId: json['scheduledBillId'] as String?,
+      title: json['title'] as String,
+      description: json['description'] as String,
+      amount: (json['amount'] as num).toDouble(),
+      currencyProfileId: json['currencyProfileId'] as String,
+      dueDate: const TimestampConverter().fromJson(json['dueDate']),
+      status: $enumDecodeNullable(_$BillStatusEnumMap, json['status']) ??
+          BillStatus.unpaid,
+      paymentMethod:
+          $enumDecodeNullable(_$PaymentMethodEnumMap, json['paymentMethod']),
+      payedAt: const NullableTimestampConverter().fromJson(json['payedAt']),
+      createdAt: const TimestampConverter().fromJson(json['createdAt']),
+      updatedAt: const NullableTimestampConverter().fromJson(json['updatedAt']),
+      deletedAt: const NullableTimestampConverter().fromJson(json['deletedAt']),
+      createdBy: json['createdBy'] as String,
+      updatedBy: json['updatedBy'] as String?,
+      deletedBy: json['deletedBy'] as String?,
+    );
 
 Map<String, dynamic> _$BillModelToJson(BillModel instance) => <String, dynamic>{
-  'id': instance.id,
-  'ownerId': instance.ownerId,
-  'clinicId': instance.clinicId,
-  'scheduledBillId': instance.scheduledBillId,
-  'title': instance.title,
-  'description': instance.description,
-  'amount': instance.amount,
-  'currencyProfileId': instance.currencyProfileId,
-  'dueDate': const TimestampConverter().toJson(instance.dueDate),
-  'status': _$BillStatusEnumMap[instance.status]!,
-  'paymentMethod': _$PaymentMethodEnumMap[instance.paymentMethod],
-  'payedAt': const NullableTimestampConverter().toJson(instance.payedAt),
-  'createdAt': const TimestampConverter().toJson(instance.createdAt),
-  'updatedAt': const NullableTimestampConverter().toJson(instance.updatedAt),
-  'deletedAt': const NullableTimestampConverter().toJson(instance.deletedAt),
-  'createdBy': instance.createdBy,
-  'updatedBy': instance.updatedBy,
-  'deletedBy': instance.deletedBy,
-};
+      'id': instance.id,
+      'ownerId': instance.ownerId,
+      'clinicId': instance.clinicId,
+      'scheduledBillId': instance.scheduledBillId,
+      'title': instance.title,
+      'description': instance.description,
+      'amount': instance.amount,
+      'currencyProfileId': instance.currencyProfileId,
+      'dueDate': const TimestampConverter().toJson(instance.dueDate),
+      'status': _$BillStatusEnumMap[instance.status]!,
+      'paymentMethod': _$PaymentMethodEnumMap[instance.paymentMethod],
+      'payedAt': const NullableTimestampConverter().toJson(instance.payedAt),
+      'createdAt': const TimestampConverter().toJson(instance.createdAt),
+      'updatedAt':
+          const NullableTimestampConverter().toJson(instance.updatedAt),
+      'deletedAt':
+          const NullableTimestampConverter().toJson(instance.deletedAt),
+      'createdBy': instance.createdBy,
+      'updatedBy': instance.updatedBy,
+      'deletedBy': instance.deletedBy,
+    };
 
 const _$BillStatusEnumMap = {
   BillStatus.unpaid: 'unpaid',
@@ -65,4 +64,3 @@ const _$PaymentMethodEnumMap = {
   PaymentMethod.bankTransfer: 'bankTransfer',
   PaymentMethod.other: 'other',
 };
-

--- a/lib/src/features/financials/domain/models/currency_profile_model.g.dart
+++ b/lib/src/features/financials/domain/models/currency_profile_model.g.dart
@@ -7,32 +7,33 @@ part of 'currency_profile_model.dart';
 // **************************************************************************
 
 CurrencyProfileModel _$CurrencyProfileModelFromJson(
-  Map<String, dynamic> json,
-) => CurrencyProfileModel(
-  id: json['id'] as String,
-  currency: json['currency'] as String,
-  name: json['name'] as String,
-  description: json['description'] as String?,
-  createdAt: const TimestampConverter().fromJson(json['createdAt']),
-  updatedAt: const NullableTimestampConverter().fromJson(json['updatedAt']),
-  deletedAt: const NullableTimestampConverter().fromJson(json['deletedAt']),
-  createdBy: json['createdBy'] as String,
-  updatedBy: json['updatedBy'] as String?,
-  deletedBy: json['deletedBy'] as String?,
-);
+        Map<String, dynamic> json) =>
+    CurrencyProfileModel(
+      id: json['id'] as String,
+      currency: json['currency'] as String,
+      name: json['name'] as String,
+      description: json['description'] as String?,
+      createdAt: const TimestampConverter().fromJson(json['createdAt']),
+      updatedAt: const NullableTimestampConverter().fromJson(json['updatedAt']),
+      deletedAt: const NullableTimestampConverter().fromJson(json['deletedAt']),
+      createdBy: json['createdBy'] as String,
+      updatedBy: json['updatedBy'] as String?,
+      deletedBy: json['deletedBy'] as String?,
+    );
 
 Map<String, dynamic> _$CurrencyProfileModelToJson(
-  CurrencyProfileModel instance,
-) => <String, dynamic>{
-  'id': instance.id,
-  'currency': instance.currency,
-  'name': instance.name,
-  'description': instance.description,
-  'createdAt': const TimestampConverter().toJson(instance.createdAt),
-  'updatedAt': const NullableTimestampConverter().toJson(instance.updatedAt),
-  'deletedAt': const NullableTimestampConverter().toJson(instance.deletedAt),
-  'createdBy': instance.createdBy,
-  'updatedBy': instance.updatedBy,
-  'deletedBy': instance.deletedBy,
-};
-
+        CurrencyProfileModel instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'currency': instance.currency,
+      'name': instance.name,
+      'description': instance.description,
+      'createdAt': const TimestampConverter().toJson(instance.createdAt),
+      'updatedAt':
+          const NullableTimestampConverter().toJson(instance.updatedAt),
+      'deletedAt':
+          const NullableTimestampConverter().toJson(instance.deletedAt),
+      'createdBy': instance.createdBy,
+      'updatedBy': instance.updatedBy,
+      'deletedBy': instance.deletedBy,
+    };

--- a/lib/src/features/financials/domain/models/goal_model.g.dart
+++ b/lib/src/features/financials/domain/models/goal_model.g.dart
@@ -24,24 +24,25 @@ CountGoalModel _$CountGoalModelFromJson(Map<String, dynamic> json) =>
       deletedBy: json['deletedBy'] as String?,
     );
 
-Map<String, dynamic> _$CountGoalModelToJson(
-  CountGoalModel instance,
-) => <String, dynamic>{
-  'id': instance.id,
-  'title': instance.title,
-  'description': instance.description,
-  'goalType': const GoalTypeConverter().toJson(instance.goalType),
-  'color': instance.color,
-  'createdAt': const TimestampConverter().toJson(instance.createdAt),
-  'updatedAt': const NullableTimestampConverter().toJson(instance.updatedAt),
-  'deletedAt': const NullableTimestampConverter().toJson(instance.deletedAt),
-  'createdBy': instance.createdBy,
-  'updatedBy': instance.updatedBy,
-  'deletedBy': instance.deletedBy,
-  'year': instance.year,
-  'month': instance.month,
-  'targetCount': instance.targetCount,
-};
+Map<String, dynamic> _$CountGoalModelToJson(CountGoalModel instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'title': instance.title,
+      'description': instance.description,
+      'goalType': const GoalTypeConverter().toJson(instance.goalType),
+      'color': instance.color,
+      'createdAt': const TimestampConverter().toJson(instance.createdAt),
+      'updatedAt':
+          const NullableTimestampConverter().toJson(instance.updatedAt),
+      'deletedAt':
+          const NullableTimestampConverter().toJson(instance.deletedAt),
+      'createdBy': instance.createdBy,
+      'updatedBy': instance.updatedBy,
+      'deletedBy': instance.deletedBy,
+      'year': instance.year,
+      'month': instance.month,
+      'targetCount': instance.targetCount,
+    };
 
 AmountGoalModel _$AmountGoalModelFromJson(Map<String, dynamic> json) =>
     AmountGoalModel(
@@ -61,24 +62,25 @@ AmountGoalModel _$AmountGoalModelFromJson(Map<String, dynamic> json) =>
       deletedBy: json['deletedBy'] as String?,
     );
 
-Map<String, dynamic> _$AmountGoalModelToJson(
-  AmountGoalModel instance,
-) => <String, dynamic>{
-  'id': instance.id,
-  'title': instance.title,
-  'description': instance.description,
-  'goalType': const GoalTypeConverter().toJson(instance.goalType),
-  'color': instance.color,
-  'createdAt': const TimestampConverter().toJson(instance.createdAt),
-  'updatedAt': const NullableTimestampConverter().toJson(instance.updatedAt),
-  'deletedAt': const NullableTimestampConverter().toJson(instance.deletedAt),
-  'createdBy': instance.createdBy,
-  'updatedBy': instance.updatedBy,
-  'deletedBy': instance.deletedBy,
-  'year': instance.year,
-  'month': instance.month,
-  'targetAmount': instance.targetAmount,
-};
+Map<String, dynamic> _$AmountGoalModelToJson(AmountGoalModel instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'title': instance.title,
+      'description': instance.description,
+      'goalType': const GoalTypeConverter().toJson(instance.goalType),
+      'color': instance.color,
+      'createdAt': const TimestampConverter().toJson(instance.createdAt),
+      'updatedAt':
+          const NullableTimestampConverter().toJson(instance.updatedAt),
+      'deletedAt':
+          const NullableTimestampConverter().toJson(instance.deletedAt),
+      'createdBy': instance.createdBy,
+      'updatedBy': instance.updatedBy,
+      'deletedBy': instance.deletedBy,
+      'year': instance.year,
+      'month': instance.month,
+      'targetAmount': instance.targetAmount,
+    };
 
 CustomGoalModel _$CustomGoalModelFromJson(Map<String, dynamic> json) =>
     CustomGoalModel(
@@ -101,25 +103,25 @@ CustomGoalModel _$CustomGoalModelFromJson(Map<String, dynamic> json) =>
       deletedBy: json['deletedBy'] as String?,
     );
 
-Map<String, dynamic> _$CustomGoalModelToJson(
-  CustomGoalModel instance,
-) => <String, dynamic>{
-  'id': instance.id,
-  'title': instance.title,
-  'description': instance.description,
-  'goalType': const GoalTypeConverter().toJson(instance.goalType),
-  'color': instance.color,
-  'createdAt': const TimestampConverter().toJson(instance.createdAt),
-  'updatedAt': const NullableTimestampConverter().toJson(instance.updatedAt),
-  'deletedAt': const NullableTimestampConverter().toJson(instance.deletedAt),
-  'createdBy': instance.createdBy,
-  'updatedBy': instance.updatedBy,
-  'deletedBy': instance.deletedBy,
-  'year': instance.year,
-  'month': instance.month,
-  'metricName': instance.metricName,
-  'targetValue': instance.targetValue,
-  'isMonthBased': instance.isMonthBased,
-  'isYearBased': instance.isYearBased,
-};
-
+Map<String, dynamic> _$CustomGoalModelToJson(CustomGoalModel instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'title': instance.title,
+      'description': instance.description,
+      'goalType': const GoalTypeConverter().toJson(instance.goalType),
+      'color': instance.color,
+      'createdAt': const TimestampConverter().toJson(instance.createdAt),
+      'updatedAt':
+          const NullableTimestampConverter().toJson(instance.updatedAt),
+      'deletedAt':
+          const NullableTimestampConverter().toJson(instance.deletedAt),
+      'createdBy': instance.createdBy,
+      'updatedBy': instance.updatedBy,
+      'deletedBy': instance.deletedBy,
+      'year': instance.year,
+      'month': instance.month,
+      'metricName': instance.metricName,
+      'targetValue': instance.targetValue,
+      'isMonthBased': instance.isMonthBased,
+      'isYearBased': instance.isYearBased,
+    };

--- a/lib/src/features/financials/domain/models/invoice_model.g.dart
+++ b/lib/src/features/financials/domain/models/invoice_model.g.dart
@@ -7,55 +7,54 @@ part of 'invoice_model.dart';
 // **************************************************************************
 
 InvoiceModel _$InvoiceModelFromJson(Map<String, dynamic> json) => InvoiceModel(
-  id: json['id'] as String,
-  ownerId: json['ownerId'] as String,
-  clinicId: json['clinicId'] as String,
-  title: json['title'] as String,
-  description: json['description'] as String,
-  amount: (json['amount'] as num).toDouble(),
-  currencyProfileId: json['currencyProfileId'] as String,
-  issuedAt: const TimestampConverter().fromJson(json['issuedAt']),
-  createdAt: const TimestampConverter().fromJson(json['createdAt']),
-  updatedAt: const NullableTimestampConverter().fromJson(json['updatedAt']),
-  deletedAt: const NullableTimestampConverter().fromJson(json['deletedAt']),
-  createdBy: json['createdBy'] as String,
-  updatedBy: json['updatedBy'] as String?,
-  deletedBy: json['deletedBy'] as String?,
-  dueDate: const TimestampConverter().fromJson(json['dueDate']),
-  customerId: json['customerId'] as String?,
-  customerType: $enumDecodeNullable(
-    _$CustomerTypeEnumMap,
-    json['customerType'],
-  ),
-  source: $enumDecodeNullable(_$InvoiceSourceEnumMap, json['source']),
-  status: $enumDecodeNullable(_$InvoiceStatusEnumMap, json['status']),
-  referenceId: json['referenceId'] as String,
-);
+      id: json['id'] as String,
+      ownerId: json['ownerId'] as String,
+      clinicId: json['clinicId'] as String,
+      title: json['title'] as String,
+      description: json['description'] as String,
+      amount: (json['amount'] as num).toDouble(),
+      currencyProfileId: json['currencyProfileId'] as String,
+      issuedAt: const TimestampConverter().fromJson(json['issuedAt']),
+      createdAt: const TimestampConverter().fromJson(json['createdAt']),
+      updatedAt: const NullableTimestampConverter().fromJson(json['updatedAt']),
+      deletedAt: const NullableTimestampConverter().fromJson(json['deletedAt']),
+      createdBy: json['createdBy'] as String,
+      updatedBy: json['updatedBy'] as String?,
+      deletedBy: json['deletedBy'] as String?,
+      dueDate: const TimestampConverter().fromJson(json['dueDate']),
+      customerId: json['customerId'] as String?,
+      customerType:
+          $enumDecodeNullable(_$CustomerTypeEnumMap, json['customerType']),
+      source: $enumDecodeNullable(_$InvoiceSourceEnumMap, json['source']),
+      status: $enumDecodeNullable(_$InvoiceStatusEnumMap, json['status']),
+      referenceId: json['referenceId'] as String,
+    );
 
-Map<String, dynamic> _$InvoiceModelToJson(
-  InvoiceModel instance,
-) => <String, dynamic>{
-  'id': instance.id,
-  'ownerId': instance.ownerId,
-  'clinicId': instance.clinicId,
-  'title': instance.title,
-  'description': instance.description,
-  'amount': instance.amount,
-  'currencyProfileId': instance.currencyProfileId,
-  'issuedAt': const TimestampConverter().toJson(instance.issuedAt),
-  'createdAt': const TimestampConverter().toJson(instance.createdAt),
-  'createdBy': instance.createdBy,
-  'updatedBy': instance.updatedBy,
-  'deletedBy': instance.deletedBy,
-  'updatedAt': const NullableTimestampConverter().toJson(instance.updatedAt),
-  'deletedAt': const NullableTimestampConverter().toJson(instance.deletedAt),
-  'dueDate': const TimestampConverter().toJson(instance.dueDate),
-  'customerId': instance.customerId,
-  'customerType': _$CustomerTypeEnumMap[instance.customerType],
-  'source': _$InvoiceSourceEnumMap[instance.source],
-  'status': _$InvoiceStatusEnumMap[instance.status],
-  'referenceId': instance.referenceId,
-};
+Map<String, dynamic> _$InvoiceModelToJson(InvoiceModel instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'ownerId': instance.ownerId,
+      'clinicId': instance.clinicId,
+      'title': instance.title,
+      'description': instance.description,
+      'amount': instance.amount,
+      'currencyProfileId': instance.currencyProfileId,
+      'issuedAt': const TimestampConverter().toJson(instance.issuedAt),
+      'createdAt': const TimestampConverter().toJson(instance.createdAt),
+      'createdBy': instance.createdBy,
+      'updatedBy': instance.updatedBy,
+      'deletedBy': instance.deletedBy,
+      'updatedAt':
+          const NullableTimestampConverter().toJson(instance.updatedAt),
+      'deletedAt':
+          const NullableTimestampConverter().toJson(instance.deletedAt),
+      'dueDate': const TimestampConverter().toJson(instance.dueDate),
+      'customerId': instance.customerId,
+      'customerType': _$CustomerTypeEnumMap[instance.customerType],
+      'source': _$InvoiceSourceEnumMap[instance.source],
+      'status': _$InvoiceStatusEnumMap[instance.status],
+      'referenceId': instance.referenceId,
+    };
 
 const _$CustomerTypeEnumMap = {
   CustomerType.patient: 'patient',
@@ -74,4 +73,3 @@ const _$InvoiceStatusEnumMap = {
   InvoiceStatus.paid: 'paid',
   InvoiceStatus.partiallyPaid: 'partiallyPaid',
 };
-

--- a/lib/src/features/financials/domain/models/scheduled_bill_model.g.dart
+++ b/lib/src/features/financials/domain/models/scheduled_bill_model.g.dart
@@ -13,8 +13,7 @@ ScheduledBillModel _$ScheduledBillModelFromJson(Map<String, dynamic> json) =>
       description: json['description'] as String,
       amount: (json['amount'] as num).toDouble(),
       currencyProfileId: json['currencyProfileId'] as String,
-      type:
-          $enumDecodeNullable(_$ScheduledBillTypeEnumMap, json['type']) ??
+      type: $enumDecodeNullable(_$ScheduledBillTypeEnumMap, json['type']) ??
           ScheduledBillType.expense,
       scheduledAt: const TimestampConverter().fromJson(json['scheduledAt']),
       createdAt: const TimestampConverter().fromJson(json['createdAt']),
@@ -23,32 +22,30 @@ ScheduledBillModel _$ScheduledBillModelFromJson(Map<String, dynamic> json) =>
       createdBy: json['createdBy'] as String,
       updatedBy: json['updatedBy'] as String?,
       deletedBy: json['deletedBy'] as String?,
-      recurrence:
-          $enumDecodeNullable(
-            _$ScheduledBillRecurrenceEnumMap,
-            json['recurrence'],
-          ) ??
+      recurrence: $enumDecodeNullable(
+              _$ScheduledBillRecurrenceEnumMap, json['recurrence']) ??
           ScheduledBillRecurrence.none,
     );
 
-Map<String, dynamic> _$ScheduledBillModelToJson(
-  ScheduledBillModel instance,
-) => <String, dynamic>{
-  'id': instance.id,
-  'title': instance.title,
-  'description': instance.description,
-  'amount': instance.amount,
-  'currencyProfileId': instance.currencyProfileId,
-  'type': _$ScheduledBillTypeEnumMap[instance.type]!,
-  'scheduledAt': const TimestampConverter().toJson(instance.scheduledAt),
-  'createdAt': const TimestampConverter().toJson(instance.createdAt),
-  'updatedAt': const NullableTimestampConverter().toJson(instance.updatedAt),
-  'deletedAt': const NullableTimestampConverter().toJson(instance.deletedAt),
-  'createdBy': instance.createdBy,
-  'updatedBy': instance.updatedBy,
-  'deletedBy': instance.deletedBy,
-  'recurrence': _$ScheduledBillRecurrenceEnumMap[instance.recurrence]!,
-};
+Map<String, dynamic> _$ScheduledBillModelToJson(ScheduledBillModel instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'title': instance.title,
+      'description': instance.description,
+      'amount': instance.amount,
+      'currencyProfileId': instance.currencyProfileId,
+      'type': _$ScheduledBillTypeEnumMap[instance.type]!,
+      'scheduledAt': const TimestampConverter().toJson(instance.scheduledAt),
+      'createdAt': const TimestampConverter().toJson(instance.createdAt),
+      'updatedAt':
+          const NullableTimestampConverter().toJson(instance.updatedAt),
+      'deletedAt':
+          const NullableTimestampConverter().toJson(instance.deletedAt),
+      'createdBy': instance.createdBy,
+      'updatedBy': instance.updatedBy,
+      'deletedBy': instance.deletedBy,
+      'recurrence': _$ScheduledBillRecurrenceEnumMap[instance.recurrence]!,
+    };
 
 const _$ScheduledBillTypeEnumMap = {
   ScheduledBillType.income: 'income',
@@ -61,4 +58,3 @@ const _$ScheduledBillRecurrenceEnumMap = {
   ScheduledBillRecurrence.monthly: 'monthly',
   ScheduledBillRecurrence.yearly: 'yearly',
 };
-

--- a/lib/src/features/financials/presentation/bloc/financials_bloc.dart
+++ b/lib/src/features/financials/presentation/bloc/financials_bloc.dart
@@ -219,23 +219,8 @@ class FinancialsBloc extends Bloc<FinancialsEvent, FinancialsState> {
     add(GetEvaluationsCountForYear(year));
     add(GetEvaluationsCountForMonth(year, month));
 
-    /// Iterates through the next 12 months starting from the current month,
-    /// calculates the corresponding month and year for each iteration,
-    /// and dispatches two events for each month:
-    /// - `GetSessionsCountForMonth` to retrieve the session count for the month.
-    /// - `GetEvaluationsCountForMonth` to retrieve the evaluation count for the month.
-    ///
-    /// The calculation for the month uses modulo 12 to ensure it wraps around
-    /// correctly after December, and the year is adjusted accordingly based on
-    /// the overflow from the month calculation.
-    // Always fetch data for all months in the current year (January to December)
-    // Fetch data for all months in the current year and two years before
-    for (int y = year - 2; y <= year; y++) {
-      for (int m = 1; m <= 12; m++) {
-        add(GetTotalRevenueForMonth(y, m));
-        add(GetTotalExpensesForMonth(y, m));
-      }
-    }
+    // Initial transaction data fetching has been removed as it requires clinicId.
+    // The UI should trigger these events with the correct clinicId on load.
   }
 
   /// Emits a [FinancialsSuccess] state with the provided [message].
@@ -658,6 +643,15 @@ class FinancialsBloc extends Bloc<FinancialsEvent, FinancialsState> {
     required DateTime to,
     required Set<String> existingBillsDueDates,
   }) {
+    final ownerId = OwnerNotifier().ownerId;
+    final clinicId = OwnerNotifier().clinicId;
+
+    // Return empty list if user doesn't have clinic/owner ID
+    if (ownerId == null || clinicId == null) {
+      debugPrint('Cannot generate bills: ownerId or clinicId is null');
+      return [];
+    }
+
     final dueDates = getDueDates(scheduledBill, from: from, to: to);
     final uuid = Uuid();
     return dueDates
@@ -674,10 +668,8 @@ class FinancialsBloc extends Bloc<FinancialsEvent, FinancialsState> {
               status: BillStatus.unpaid,
               createdAt: Timestamp.fromDate(DateTime.now().toUtc()),
               createdBy: scheduledBill.createdBy,
-              ownerId:
-                  OwnerNotifier().ownerId!, //will be added at repository layer
-              clinicId:
-                  OwnerNotifier().clinicId!, //will be added at repository layer
+              ownerId: ownerId,
+              clinicId: clinicId,
             ))
         .toList();
   }
@@ -797,13 +789,14 @@ class FinancialsBloc extends Bloc<FinancialsEvent, FinancialsState> {
 
   Future<void> _onFetchTotalRevenueForYear(
       FetchTotalRevenueForYear event, Emitter<FinancialsState> emit) async {
-    final result = await transactionsUseCase.getTotalRevenueForYear(event.year);
+    final result = await transactionsUseCase.getTotalRevenueForYear(
+        event.clinicId, event.year);
     result.fold(
       (failure) => emit(errorState(message: _mapFailureToMessage(failure))),
-      (totalRevenue) {
-        final updatedRevenuePerYear =
-            Map<String, double>.from(state.revenuePerYear);
-        updatedRevenuePerYear[event.year.toString()] = totalRevenue;
+      (acc) {
+        final key = event.year.toString().padLeft(4, '0');
+        final updatedMap = Map<String, double>.from(state.revenuePerYear);
+        updatedMap[key] = acc;
         emit(FinancialsLoaded(
           scheduledBills: state.scheduledBills,
           goals: state.goals,
@@ -811,9 +804,9 @@ class FinancialsBloc extends Bloc<FinancialsEvent, FinancialsState> {
           bills: state.bills,
           sessionsCountPerMonth: state.sessionsCountPerMonth,
           evaluationsCountPerMonth: state.evaluationsCountPerMonth,
-          revenuePerMonth: state.revenuePerMonth,
           expensesPerMonth: state.expensesPerMonth,
-          revenuePerYear: updatedRevenuePerYear,
+          revenuePerMonth: state.revenuePerMonth,
+          revenuePerYear: updatedMap,
           expensesPerYear: state.expensesPerYear,
         ));
       },
@@ -822,8 +815,8 @@ class FinancialsBloc extends Bloc<FinancialsEvent, FinancialsState> {
 
   Future<void> _onFetchTotalExpensesForYear(
       FetchTotalExpensesForYear event, Emitter<FinancialsState> emit) async {
-    final result =
-        await transactionsUseCase.getTotalExpensesForYear(event.year);
+    final result = await transactionsUseCase.getTotalExpensesForYear(
+        event.clinicId, event.year);
     result.fold(
       (failure) => emit(errorState(message: _mapFailureToMessage(failure))),
       (totalExpenses) {
@@ -853,7 +846,7 @@ class FinancialsBloc extends Bloc<FinancialsEvent, FinancialsState> {
     );
     // Fetch the total revenue for the specified month and year
     final result = await transactionsUseCase.getTotalRevenueForMonth(
-        event.year, event.month);
+        event.clinicId, event.year, event.month);
     result.fold(
       (failure) => emit(errorState(message: _mapFailureToMessage(failure))),
       (total) {
@@ -884,7 +877,7 @@ class FinancialsBloc extends Bloc<FinancialsEvent, FinancialsState> {
   Future<void> _onFetchTotalExpensesForMonth(
       GetTotalExpensesForMonth event, Emitter<FinancialsState> emit) async {
     final result = await transactionsUseCase.getTotalExpensesForMonth(
-        event.year, event.month);
+        event.clinicId, event.year, event.month);
     result.fold(
       (failure) => emit(errorState(message: _mapFailureToMessage(failure))),
       (total) {
@@ -916,6 +909,7 @@ class FinancialsBloc extends Bloc<FinancialsEvent, FinancialsState> {
       FetchTotalByDirectionAndSource event,
       Emitter<FinancialsState> emit) async {
     final result = await transactionsUseCase.getTotalByDirectionAndSource(
+      clinicId: event.clinicId,
       direction: event.direction,
       source: event.source,
       year: event.year,
@@ -996,4 +990,3 @@ class FinancialsBloc extends Bloc<FinancialsEvent, FinancialsState> {
     emit(successState(message: 'billHasPaid'.tr(args: [bill.title])));
   }
 }
-

--- a/lib/src/features/financials/presentation/bloc/financials_event.dart
+++ b/lib/src/features/financials/presentation/bloc/financials_event.dart
@@ -265,52 +265,58 @@ class DeleteTransaction extends FinancialsEvent {
 
 /// Event to fetch total revenue (inwards) for a given year.
 class FetchTotalRevenueForYear extends FinancialsEvent {
+  final String clinicId;
   final int year;
-  const FetchTotalRevenueForYear(this.year);
+  const FetchTotalRevenueForYear(this.clinicId, this.year);
   @override
-  List<Object?> get props => [year];
+  List<Object?> get props => [clinicId, year];
 }
 
 /// Event to fetch total expenses (outwards) for a given year.
 class FetchTotalExpensesForYear extends FinancialsEvent {
+  final String clinicId;
   final int year;
-  const FetchTotalExpensesForYear(this.year);
+  const FetchTotalExpensesForYear(this.clinicId, this.year);
   @override
-  List<Object?> get props => [year];
+  List<Object?> get props => [clinicId, year];
 }
 
 /// Event to fetch total revenue (inwards) for a given month and year.
 class GetTotalRevenueForMonth extends FinancialsEvent {
+  final String clinicId;
   final int year;
   final int month;
-  const GetTotalRevenueForMonth(this.year, this.month);
+  const GetTotalRevenueForMonth(this.clinicId, this.year, this.month);
   @override
-  List<Object?> get props => [year, month];
+  List<Object?> get props => [clinicId, year, month];
 }
 
 /// Event to fetch total expenses (outwards) for a given month and year.
 class GetTotalExpensesForMonth extends FinancialsEvent {
+  final String clinicId;
   final int year;
   final int month;
-  const GetTotalExpensesForMonth(this.year, this.month);
+  const GetTotalExpensesForMonth(this.clinicId, this.year, this.month);
   @override
-  List<Object?> get props => [year, month];
+  List<Object?> get props => [clinicId, year, month];
 }
 
 /// Event to fetch total for a given direction and optional source, year, and month.
 class FetchTotalByDirectionAndSource extends FinancialsEvent {
+  final String clinicId;
   final TransactionDirection direction;
   final TransactionSource? source;
   final int? year;
   final int? month;
   const FetchTotalByDirectionAndSource({
+    required this.clinicId,
     required this.direction,
     this.source,
     this.year,
     this.month,
   });
   @override
-  List<Object?> get props => [direction, source, year, month];
+  List<Object?> get props => [clinicId, direction, source, year, month];
 }
 
 ///Event to pay a bill
@@ -320,4 +326,3 @@ class PayBill extends FinancialsEvent {
   @override
   List<Object?> get props => [bill];
 }
-

--- a/lib/src/features/financials/presentation/pages/dashboard_page.dart
+++ b/lib/src/features/financials/presentation/pages/dashboard_page.dart
@@ -147,7 +147,7 @@ class DashboardPage extends StatelessWidget {
                                 color: Colors.blue,
                                 title: '${now.year} ${'sessions'.tr()}',
                                 value: sessionsYear.toString(),
-                                icon: Icons.event,
+                                icon: Icons.event_outlined,
                               ),
                             ),
                             const SizedBox(width: 12),
@@ -159,7 +159,7 @@ class DashboardPage extends StatelessWidget {
                                 title:
                                     '${DateFormat.MMMM(Localizations.localeOf(context).toString()).format(now)} ${'sessions'.tr()}',
                                 value: sessionsMonth.toString(),
-                                icon: Icons.event_available,
+                                icon: Icons.event_available_outlined,
                               ),
                             ),
                             const SizedBox(width: 12),
@@ -170,7 +170,7 @@ class DashboardPage extends StatelessWidget {
                                 color: Colors.purple,
                                 title: '${now.year} ${'evaluations'.tr()}',
                                 value: evalsYear.toString(),
-                                icon: Icons.assignment,
+                                icon: Icons.assignment_outlined,
                               ),
                             ),
                             const SizedBox(width: 12),
@@ -182,7 +182,7 @@ class DashboardPage extends StatelessWidget {
                                 title:
                                     '${DateFormat.MMMM(Localizations.localeOf(context).toString()).format(now)} ${'evaluations'.tr()}',
                                 value: evalsMonth.toString(),
-                                icon: Icons.assignment_turned_in,
+                                icon: Icons.assignment_turned_in_outlined,
                               ),
                             ),
                           ],
@@ -221,7 +221,8 @@ class DashboardPage extends StatelessWidget {
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [
-                        Icon(Icons.inbox, size: 48, color: Colors.grey[400]),
+                        Icon(Icons.inbox_outlined,
+                            size: 48, color: Colors.grey[400]),
                         const SizedBox(height: 12),
                         Text(
                           'noTransactions'.tr(),

--- a/lib/src/features/financials/presentation/widgets/dashboard_view.dart
+++ b/lib/src/features/financials/presentation/widgets/dashboard_view.dart
@@ -29,7 +29,7 @@ class DashboardView extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Financial Dashboard'),
-        leading: const Icon(Icons.dashboard),
+        leading: const Icon(Icons.dashboard_outlined),
       ),
       body: SingleChildScrollView(
         padding: const EdgeInsets.all(16.0),
@@ -52,14 +52,14 @@ class DashboardView extends StatelessWidget {
                   title: 'Sessions',
                   monthValue: sessionsThisMonth,
                   yearValue: sessionsThisYear,
-                  icon: Icons.event_note,
+                  icon: Icons.event_note_outlined,
                   color: Colors.blue,
                 ),
                 _SummaryCard(
                   title: 'Evaluations',
                   monthValue: evaluationsThisMonth,
                   yearValue: evaluationsThisYear,
-                  icon: Icons.assessment,
+                  icon: Icons.assessment_outlined,
                   color: Colors.purple,
                 ),
                 _SummaryCard(
@@ -74,7 +74,7 @@ class DashboardView extends StatelessWidget {
                   title: 'Expenses',
                   monthValue: totalExpensesThisMonth.toInt(),
                   yearValue: null,
-                  icon: Icons.money_off,
+                  icon: Icons.money_off_outlined,
                   color: Colors.red,
                   isCurrency: true,
                 ),

--- a/lib/src/features/financials/transactions/data/remote/transactions_firebase_api.dart
+++ b/lib/src/features/financials/transactions/data/remote/transactions_firebase_api.dart
@@ -1,9 +1,12 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:dartz/dartz.dart';
-import 'package:dr_copilot/src/core/app/notifiers/owner_notifier.dart';
+
 import 'package:dr_copilot/src/core/error/failures.dart';
 import 'package:dr_copilot/src/features/financials/transactions/domain/models/transaction_model.dart';
 import 'package:dr_copilot/src/features/financials/transactions/domain/repositories/abstract_financials_repository.dart';
+import 'package:dr_copilot/src/core/app/notifiers/owner_notifier.dart';
+import 'package:dr_copilot/src/features/auth/domain/models/permission_enum.dart';
+
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/foundation.dart';
 import 'dart:io';
@@ -13,11 +16,9 @@ class TransactionsFirebaseApi extends AbstractTransactionsRepository {
   final CollectionReference _transactionsCollection =
       FirebaseFirestore.instance.collection('transactions');
 
-  String? get ownerId => OwnerNotifier().ownerId;
-
-  /// Ensures all queries are scoped to the current user.
-  Query _userScopedQuery() =>
-      _transactionsCollection.where('ownerId', isEqualTo: ownerId);
+  /// Ensures all queries are scoped to the current clinic.
+  Query _clinicScopedQuery(String clinicId) =>
+      _transactionsCollection.where('clinicId', isEqualTo: clinicId);
 
   /// Checks if the user is authenticated.
   ///
@@ -34,6 +35,9 @@ class TransactionsFirebaseApi extends AbstractTransactionsRepository {
   @override
   Future<Either<Failure, TransactionModel>> addTransaction(
       TransactionModel transaction) async {
+    if (!OwnerNotifier().hasPermission(AppPermission.addFinancialEntry)) {
+      return Left(ServerFailure('Permission denied', 403));
+    }
     try {
       await _transactionsCollection
           .doc(transaction.id)
@@ -47,11 +51,15 @@ class TransactionsFirebaseApi extends AbstractTransactionsRepository {
   /// Fetches transactions with optional pagination.
   @override
   Future<Either<Failure, List<TransactionModel>>> getTransactions({
+    required String clinicId,
     String? lastDocumentId,
     int limit = 20,
   }) async {
+    if (!OwnerNotifier().hasPermission(AppPermission.viewFinancials)) {
+      return Left(ServerFailure('Permission denied', 403));
+    }
     try {
-      Query query = _userScopedQuery()
+      Query query = _clinicScopedQuery(clinicId)
           .orderBy('transactionDate', descending: true)
           .limit(limit);
 
@@ -77,6 +85,9 @@ class TransactionsFirebaseApi extends AbstractTransactionsRepository {
   @override
   Future<Either<Failure, TransactionModel>> updateTransaction(
       String id, TransactionModel transaction) async {
+    if (!OwnerNotifier().hasPermission(AppPermission.editFinancialEntry)) {
+      return Left(ServerFailure('Permission denied', 403));
+    }
     try {
       final user = FirebaseAuth.instance.currentUser;
       if (user != null) {
@@ -100,7 +111,7 @@ class TransactionsFirebaseApi extends AbstractTransactionsRepository {
             updatedData['updatedAt'] = Timestamp.fromDate(
                 DateTime.now().toUtc()); // Add updatedAt field
             await _transactionsCollection.doc(id).update(updatedData);
-            _userScopedQuery();
+            // _userScopedQuery(); // Removed useless call
             return Right(transaction.copyWith(id: id));
           } else {
             return Left(ServerFailure('Unauthorized', 403));
@@ -118,6 +129,9 @@ class TransactionsFirebaseApi extends AbstractTransactionsRepository {
   /// Deletes a transaction by its ID.
   @override
   Future<Either<Failure, void>> deleteTransaction(String id) async {
+    if (!OwnerNotifier().hasPermission(AppPermission.deleteFinancialEntry)) {
+      return Left(ServerFailure('Permission denied', 403));
+    }
     try {
       await _transactionsCollection.doc(id).delete();
       return const Right(null);
@@ -130,11 +144,14 @@ class TransactionsFirebaseApi extends AbstractTransactionsRepository {
   /// Searches transactions by description.
   @override
   Future<Either<Failure, List<TransactionModel>>> searchTransactions(
-      {String? description}) async {
+      {required String clinicId, String? description}) async {
+    if (!OwnerNotifier().hasPermission(AppPermission.viewFinancials)) {
+      return Left(ServerFailure('Permission denied', 403));
+    }
     try {
       final user = FirebaseAuth.instance.currentUser;
       if (user != null) {
-        Query queryRef = _userScopedQuery();
+        Query queryRef = _clinicScopedQuery(clinicId);
 
         if (description != null && description.isNotEmpty) {
           queryRef = queryRef
@@ -170,13 +187,15 @@ class TransactionsFirebaseApi extends AbstractTransactionsRepository {
   /// Fetches transactions by a specific date.
   @override
   Future<Either<Failure, List<TransactionModel>>> getTransactionsByDate(
-      DateTime date,
-      {String? lastDocumentID,
-      int limit = 20}) async {
+      String clinicId, DateTime date,
+      {String? lastDocumentID, int limit = 20}) async {
+    if (!OwnerNotifier().hasPermission(AppPermission.viewFinancials)) {
+      return Left(ServerFailure('Permission denied', 403));
+    }
     try {
       final user = FirebaseAuth.instance.currentUser;
       if (user != null) {
-        Query queryRef = _userScopedQuery()
+        Query queryRef = _clinicScopedQuery(clinicId)
             .where('transactionDate',
                 isGreaterThanOrEqualTo: Timestamp.fromDate(
                     DateTime(date.year, date.month, date.day)))
@@ -214,7 +233,7 @@ class TransactionsFirebaseApi extends AbstractTransactionsRepository {
 
   /// Returns the count of transactions as an [int] or a [Failure] in case of an error.
   @override
-  Future<Either<Failure, int>> getTransactionsCount() async {
+  Future<Either<Failure, int>> getTransactionsCount(String clinicId) async {
     if (!await _isAuthenticated()) {
       debugPrint('User not authenticated');
       return Left(ServerFailure('User not authenticated', 401));
@@ -222,7 +241,7 @@ class TransactionsFirebaseApi extends AbstractTransactionsRepository {
     try {
       final user = _auth.currentUser;
       if (user != null) {
-        final snapshot = await _userScopedQuery().get();
+        final snapshot = await _clinicScopedQuery(clinicId).get();
         return Right(snapshot.docs.length);
       }
       return Left(ServerFailure('User not authenticated', 401));
@@ -234,7 +253,8 @@ class TransactionsFirebaseApi extends AbstractTransactionsRepository {
 
   /// Aggregates and returns the total revenue for a given year using Firestore aggregation.
   @override
-  Future<Either<Failure, double>> getTotalRevenueForYear(int year) async {
+  Future<Either<Failure, double>> getTotalRevenueForYear(
+      String clinicId, int year) async {
     try {
       final user = FirebaseAuth.instance.currentUser;
       if (user == null) {
@@ -243,7 +263,7 @@ class TransactionsFirebaseApi extends AbstractTransactionsRepository {
 
       final start = DateTime(year, 1, 1);
       final end = DateTime(year + 1, 1, 1);
-      final query = _userScopedQuery()
+      final query = _clinicScopedQuery(clinicId)
           .where('transactionDate',
               isGreaterThanOrEqualTo: Timestamp.fromDate(start))
           .where('transactionDate', isLessThan: Timestamp.fromDate(end))
@@ -281,7 +301,8 @@ class TransactionsFirebaseApi extends AbstractTransactionsRepository {
 
   /// Aggregates and returns the total expenses for a given year using Firestore aggregation.
   @override
-  Future<Either<Failure, double>> getTotalExpensesForYear(int year) async {
+  Future<Either<Failure, double>> getTotalExpensesForYear(
+      String clinicId, int year) async {
     try {
       final user = FirebaseAuth.instance.currentUser;
       if (user == null) {
@@ -290,7 +311,7 @@ class TransactionsFirebaseApi extends AbstractTransactionsRepository {
 
       final start = DateTime(year, 1, 1);
       final end = DateTime(year + 1, 1, 1);
-      final query = _userScopedQuery()
+      final query = _clinicScopedQuery(clinicId)
           .where('transactionDate',
               isGreaterThanOrEqualTo: Timestamp.fromDate(start))
           .where('transactionDate', isLessThan: Timestamp.fromDate(end))
@@ -329,7 +350,7 @@ class TransactionsFirebaseApi extends AbstractTransactionsRepository {
   /// Aggregates and returns the total revenue for a given year and month using Firestore aggregation.
   @override
   Future<Either<Failure, double>> getTotalRevenueForMonth(
-      int year, int month) async {
+      String clinicId, int year, int month) async {
     try {
       final user = FirebaseAuth.instance.currentUser;
       if (user == null) {
@@ -340,7 +361,7 @@ class TransactionsFirebaseApi extends AbstractTransactionsRepository {
       final end = (month == 12)
           ? DateTime(year + 1, 1, 1)
           : DateTime(year, month + 1, 1);
-      final query = _userScopedQuery()
+      final query = _clinicScopedQuery(clinicId)
           .where('transactionDate',
               isGreaterThanOrEqualTo: Timestamp.fromDate(start))
           .where('transactionDate', isLessThan: Timestamp.fromDate(end))
@@ -379,7 +400,7 @@ class TransactionsFirebaseApi extends AbstractTransactionsRepository {
   /// Aggregates and returns the total expenses for a given year and month using Firestore aggregation.
   @override
   Future<Either<Failure, double>> getTotalExpensesForMonth(
-      int year, int month) async {
+      String clinicId, int year, int month) async {
     try {
       final user = FirebaseAuth.instance.currentUser;
       if (user == null) {
@@ -390,7 +411,7 @@ class TransactionsFirebaseApi extends AbstractTransactionsRepository {
       final end = (month == 12)
           ? DateTime(year + 1, 1, 1)
           : DateTime(year, month + 1, 1);
-      final query = _userScopedQuery()
+      final query = _clinicScopedQuery(clinicId)
           .where('transactionDate',
               isGreaterThanOrEqualTo: Timestamp.fromDate(start))
           .where('transactionDate', isLessThan: Timestamp.fromDate(end))
@@ -429,6 +450,7 @@ class TransactionsFirebaseApi extends AbstractTransactionsRepository {
   /// Aggregates and returns the total for a given direction and optional source, year, and month.
   @override
   Future<Either<Failure, double>> getTotalByDirectionAndSource({
+    required String clinicId, // Added clinicId
     required TransactionDirection direction,
     TransactionSource? source,
     int? year,
@@ -440,7 +462,7 @@ class TransactionsFirebaseApi extends AbstractTransactionsRepository {
         return Left(ServerFailure('User not authenticated', 401));
       }
 
-      Query query = _userScopedQuery();
+      Query query = _clinicScopedQuery(clinicId);
 
       if (year != null) {
         final start = DateTime(year, month ?? 1, 1);
@@ -521,9 +543,9 @@ class TransactionsFirebaseApi extends AbstractTransactionsRepository {
   /// Deletes transactions by their reference ID.
   @override
   Future<Either<Failure, void>> deleteTransactionByReferenceId(
-      String referenceId) async {
+      String clinicId, String referenceId) async {
     try {
-      final querySnapshot = await _userScopedQuery()
+      final querySnapshot = await _clinicScopedQuery(clinicId)
           .where('referenceId', isEqualTo: referenceId)
           .get();
 
@@ -537,4 +559,3 @@ class TransactionsFirebaseApi extends AbstractTransactionsRepository {
     }
   }
 }
-

--- a/lib/src/features/financials/transactions/data/repositories/transactions_repository_impl.dart
+++ b/lib/src/features/financials/transactions/data/repositories/transactions_repository_impl.dart
@@ -12,10 +12,16 @@ class TransactionsRepositoryImpl extends AbstractTransactionsRepository {
 
   /// Gets a list of transactions.
   @override
-  Future<Either<Failure, List<TransactionModel>>> getTransactions(
-      {String? lastDocumentId, int limit = 20}) {
+  Future<Either<Failure, List<TransactionModel>>> getTransactions({
+    required String clinicId,
+    String? lastDocumentId,
+    int limit = 20,
+  }) {
     return firebaseApi.getTransactions(
-        lastDocumentId: lastDocumentId, limit: limit);
+      clinicId: clinicId,
+      lastDocumentId: lastDocumentId,
+      limit: limit,
+    );
   }
 
   /// Adds a new transaction.
@@ -40,60 +46,80 @@ class TransactionsRepositoryImpl extends AbstractTransactionsRepository {
 
   /// Searches transactions based on criteria.
   @override
-  Future<Either<Failure, List<TransactionModel>>> searchTransactions(
-      {String? description}) {
-    return firebaseApi.searchTransactions(description: description);
+  Future<Either<Failure, List<TransactionModel>>> searchTransactions({
+    required String clinicId,
+    String? description,
+  }) {
+    return firebaseApi.searchTransactions(
+      clinicId: clinicId,
+      description: description,
+    );
   }
 
   /// Gets transactions by a specific date.
   @override
   Future<Either<Failure, List<TransactionModel>>> getTransactionsByDate(
-      DateTime date,
-      {String? lastDocumentID,
-      int limit = 20}) {
-    return firebaseApi.getTransactionsByDate(date, limit: limit);
+    String clinicId,
+    DateTime date, {
+    String? lastDocumentID,
+    int limit = 20,
+  }) {
+    return firebaseApi.getTransactionsByDate(
+      clinicId,
+      date,
+      lastDocumentID: lastDocumentID,
+      limit: limit,
+    );
   }
 
   /// Returns the count of transactions as an [int] or a [Failure] in case of an error.
   @override
-  Future<Either<Failure, int>> getTransactionsCount() {
-    return firebaseApi.getTransactionsCount();
+  Future<Either<Failure, int>> getTransactionsCount(String clinicId) {
+    return firebaseApi.getTransactionsCount(clinicId);
   }
 
   /// Returns the total revenue (inwards) for a given year.
   @override
-  Future<Either<Failure, double>> getTotalRevenueForYear(int year) {
-    return firebaseApi.getTotalRevenueForYear(year);
+  Future<Either<Failure, double>> getTotalRevenueForYear(
+      String clinicId, int year) {
+    return firebaseApi.getTotalRevenueForYear(clinicId, year);
   }
 
   /// Returns the total expenses (outwards) for a given year.
   @override
-  Future<Either<Failure, double>> getTotalExpensesForYear(int year) {
-    return firebaseApi.getTotalExpensesForYear(year);
+  Future<Either<Failure, double>> getTotalExpensesForYear(
+      String clinicId, int year) {
+    return firebaseApi.getTotalExpensesForYear(clinicId, year);
   }
 
   /// Returns the total revenue (inwards) for a given month and year.
   @override
-  Future<Either<Failure, double>> getTotalRevenueForMonth(int year, int month) {
-    return firebaseApi.getTotalRevenueForMonth(year, month);
+  Future<Either<Failure, double>> getTotalRevenueForMonth(
+      String clinicId, int year, int month) {
+    return firebaseApi.getTotalRevenueForMonth(clinicId, year, month);
   }
 
   /// Returns the total expenses (outwards) for a given month and year.
   @override
   Future<Either<Failure, double>> getTotalExpensesForMonth(
-      int year, int month) {
-    return firebaseApi.getTotalExpensesForMonth(year, month);
+    String clinicId,
+    int year,
+    int month,
+  ) {
+    return firebaseApi.getTotalExpensesForMonth(clinicId, year, month);
   }
 
   /// Returns the total for a given direction (inwards/outwards) and optional source.
   @override
   Future<Either<Failure, double>> getTotalByDirectionAndSource({
+    required String clinicId,
     required TransactionDirection direction,
     TransactionSource? source,
     int? year,
     int? month,
   }) {
     return firebaseApi.getTotalByDirectionAndSource(
+      clinicId: clinicId,
       direction: direction,
       source: source,
       year: year,
@@ -103,19 +129,6 @@ class TransactionsRepositoryImpl extends AbstractTransactionsRepository {
 
   /// Validates the provided reference ID and fetches the corresponding
   /// document snapshot from the remote data source.
-  ///
-  /// This method checks if the given [referenceId] is valid and attempts
-  /// to retrieve the associated document. If the operation is successful,
-  /// it returns a [DocumentSnapshot] wrapped in a [Right]. If there is a
-  /// failure, it returns a [Failure] wrapped in a [Left].
-  ///
-  /// - Parameters:
-  ///   - referenceId: The unique identifier of the reference to validate
-  ///     and fetch.
-  ///
-  /// - Returns: A [Future] containing an [Either] with a [Failure] on the
-  ///   left side if an error occurs, or a [DocumentSnapshot?] on the right
-  ///   side if the operation is successful.
   @override
   Future<Either<Failure, DocumentSnapshot?>> validateAndFetchReferenceId({
     required String referenceId,
@@ -130,8 +143,7 @@ class TransactionsRepositoryImpl extends AbstractTransactionsRepository {
   /// Deletes a transaction by its reference ID.
   @override
   Future<Either<Failure, void>> deleteTransactionByReferenceId(
-      String referenceId) async {
-    return firebaseApi.deleteTransactionByReferenceId(referenceId);
+      String clinicId, String referenceId) async {
+    return firebaseApi.deleteTransactionByReferenceId(clinicId, referenceId);
   }
 }
-

--- a/lib/src/features/financials/transactions/domain/models/transaction_model.g.dart
+++ b/lib/src/features/financials/transactions/domain/models/transaction_model.g.dart
@@ -11,12 +11,10 @@ TransactionModel _$TransactionModelFromJson(Map<String, dynamic> json) =>
       id: json['id'] as String,
       amount: (json['amount'] as num).toDouble(),
       description: json['description'] as String,
-      transactionDate: const TimestampConverter().fromJson(
-        json['transactionDate'],
-      ),
-      transactionSource: const TransactionSourceConverter().fromJson(
-        json['transactionSource'] as String,
-      ),
+      transactionDate:
+          const TimestampConverter().fromJson(json['transactionDate']),
+      transactionSource: const TransactionSourceConverter()
+          .fromJson(json['transactionSource'] as String),
       createdAt: const TimestampConverter().fromJson(json['createdAt']),
       updatedAt: const NullableTimestampConverter().fromJson(json['updatedAt']),
       createdBy: json['createdBy'] as String?,
@@ -26,54 +24,50 @@ TransactionModel _$TransactionModelFromJson(Map<String, dynamic> json) =>
       ownerId: json['ownerId'] as String,
       clinicId: json['clinicId'] as String,
       currencyProfileId: json['currencyProfileId'] as String?,
-      direction: const TransactionDirectionConverter().fromJson(
-        json['direction'] as String,
-      ),
+      direction: const TransactionDirectionConverter()
+          .fromJson(json['direction'] as String),
       notes: json['notes'] as String?,
       status: _$JsonConverterFromJson<String, TransactionStatus>(
-        json['status'],
-        const TransactionStatusConverter().fromJson,
-      ),
+          json['status'], const TransactionStatusConverter().fromJson),
       referenceId: json['referenceId'] as String,
     );
 
-Map<String, dynamic> _$TransactionModelToJson(
-  TransactionModel instance,
-) => <String, dynamic>{
-  'id': instance.id,
-  'amount': instance.amount,
-  'description': instance.description,
-  'transactionDate': const TimestampConverter().toJson(
-    instance.transactionDate,
-  ),
-  'transactionSource': const TransactionSourceConverter().toJson(
-    instance.transactionSource,
-  ),
-  'direction': const TransactionDirectionConverter().toJson(instance.direction),
-  'createdAt': const TimestampConverter().toJson(instance.createdAt),
-  'deletedAt': const NullableTimestampConverter().toJson(instance.deletedAt),
-  'updatedAt': const NullableTimestampConverter().toJson(instance.updatedAt),
-  'ownerId': instance.ownerId,
-  'clinicId': instance.clinicId,
-  'createdBy': instance.createdBy,
-  'deletedBy': instance.deletedBy,
-  'updatedBy': instance.updatedBy,
-  'currencyProfileId': instance.currencyProfileId,
-  'notes': instance.notes,
-  'status': _$JsonConverterToJson<String, TransactionStatus>(
-    instance.status,
-    const TransactionStatusConverter().toJson,
-  ),
-  'referenceId': instance.referenceId,
-};
+Map<String, dynamic> _$TransactionModelToJson(TransactionModel instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'amount': instance.amount,
+      'description': instance.description,
+      'transactionDate':
+          const TimestampConverter().toJson(instance.transactionDate),
+      'transactionSource':
+          const TransactionSourceConverter().toJson(instance.transactionSource),
+      'direction':
+          const TransactionDirectionConverter().toJson(instance.direction),
+      'createdAt': const TimestampConverter().toJson(instance.createdAt),
+      'deletedAt':
+          const NullableTimestampConverter().toJson(instance.deletedAt),
+      'updatedAt':
+          const NullableTimestampConverter().toJson(instance.updatedAt),
+      'ownerId': instance.ownerId,
+      'clinicId': instance.clinicId,
+      'createdBy': instance.createdBy,
+      'deletedBy': instance.deletedBy,
+      'updatedBy': instance.updatedBy,
+      'currencyProfileId': instance.currencyProfileId,
+      'notes': instance.notes,
+      'status': _$JsonConverterToJson<String, TransactionStatus>(
+          instance.status, const TransactionStatusConverter().toJson),
+      'referenceId': instance.referenceId,
+    };
 
 Value? _$JsonConverterFromJson<Json, Value>(
   Object? json,
   Value? Function(Json json) fromJson,
-) => json == null ? null : fromJson(json as Json);
+) =>
+    json == null ? null : fromJson(json as Json);
 
 Json? _$JsonConverterToJson<Json, Value>(
   Value? value,
   Json? Function(Value value) toJson,
-) => value == null ? null : toJson(value);
-
+) =>
+    value == null ? null : toJson(value);

--- a/lib/src/features/financials/transactions/domain/repositories/abstract_financials_repository.dart
+++ b/lib/src/features/financials/transactions/domain/repositories/abstract_financials_repository.dart
@@ -7,6 +7,7 @@ import 'package:dr_copilot/src/features/financials/transactions/domain/models/tr
 abstract class AbstractTransactionsRepository {
   /// Fetches all transactions.
   Future<Either<Failure, List<TransactionModel>>> getTransactions({
+    required String clinicId, // Added clinicId
     String? lastDocumentId,
     int limit = 20,
   });
@@ -23,33 +24,41 @@ abstract class AbstractTransactionsRepository {
   Future<Either<Failure, void>> deleteTransaction(String id);
 
   /// Returns the count of transactions as an [int] or a [Failure] in case of an error.
-  Future<Either<Failure, int>> getTransactionsCount();
+  Future<Either<Failure, int>> getTransactionsCount(
+      String clinicId); // Added clinicId
 
   /// Searches transactions based on criteria.
   Future<Either<Failure, List<TransactionModel>>> searchTransactions({
+    required String clinicId, // Added clinicId
     String? description,
   });
 
   /// Gets transactions by a specific date.
   Future<Either<Failure, List<TransactionModel>>> getTransactionsByDate(
+      String clinicId, // Added clinicId
       DateTime date,
       {String? lastDocumentID,
       int limit = 20});
 
   /// Returns the total revenue (inwards) for a given year.
-  Future<Either<Failure, double>> getTotalRevenueForYear(int year);
+  Future<Either<Failure, double>> getTotalRevenueForYear(
+      String clinicId, int year);
 
   /// Returns the total expenses (outwards) for a given year.
-  Future<Either<Failure, double>> getTotalExpensesForYear(int year);
+  Future<Either<Failure, double>> getTotalExpensesForYear(
+      String clinicId, int year);
 
   /// Returns the total revenue (inwards) for a given month and year.
-  Future<Either<Failure, double>> getTotalRevenueForMonth(int year, int month);
+  Future<Either<Failure, double>> getTotalRevenueForMonth(
+      String clinicId, int year, int month);
 
   /// Returns the total expenses (outwards) for a given month and year.
-  Future<Either<Failure, double>> getTotalExpensesForMonth(int year, int month);
+  Future<Either<Failure, double>> getTotalExpensesForMonth(
+      String clinicId, int year, int month);
 
   /// Returns the total for a given direction (inwards/outwards) and optional source.
   Future<Either<Failure, double>> getTotalByDirectionAndSource({
+    required String clinicId, // Added clinicId
     required TransactionDirection direction,
     TransactionSource? source,
     int? year,
@@ -78,6 +87,5 @@ abstract class AbstractTransactionsRepository {
 
   /// Deletes a transaction by its reference ID.
   Future<Either<Failure, void>> deleteTransactionByReferenceId(
-      String referenceId);
+      String clinicId, String referenceId);
 }
-

--- a/lib/src/features/financials/transactions/domain/usecases/transactions_usecase.dart
+++ b/lib/src/features/financials/transactions/domain/usecases/transactions_usecase.dart
@@ -13,10 +13,12 @@ class TransactionsUseCase {
 
   /// Fetches all transactions.
   Future<Either<Failure, List<TransactionModel>>> getTransactions({
+    required String clinicId, // Added clinicId
     String? lastDocumentId, // Corrected parameter name
     int? limit = 20,
   }) {
     return repository.getTransactions(
+      clinicId: clinicId, // Pass clinicId
       lastDocumentId: lastDocumentId,
       limit: limit ?? 20,
     );
@@ -40,54 +42,58 @@ class TransactionsUseCase {
 
   /// Searches transactions based on criteria.
   Future<Either<Failure, List<TransactionModel>>> searchTransactions(
-      {String? description}) async {
-    return await repository.searchTransactions(description: description);
+      {required String clinicId, String? description}) async {
+    return await repository.searchTransactions(
+        clinicId: clinicId, description: description);
   }
 
   /// Gets transactions by a specific date.
   Future<Either<Failure, List<TransactionModel>>> getTransactionsByDate(
-      DateTime date,
-      {String? lastDocumentID,
-      int limit = 20}) async {
-    return await repository.getTransactionsByDate(date,
+      String clinicId, DateTime date,
+      {String? lastDocumentID, int limit = 20}) async {
+    return await repository.getTransactionsByDate(clinicId, date,
         lastDocumentID: lastDocumentID, limit: limit);
   }
 
   /// Returns the count of transactions as an [int] or a [Failure] in case of an error.
-  Future<Either<Failure, int>> getTransactionsCount() async {
-    return await repository.getTransactionsCount();
+  Future<Either<Failure, int>> getTransactionsCount(String clinicId) async {
+    return await repository.getTransactionsCount(clinicId);
   }
 
   /// Returns the total revenue (inwards) for a given year.
-  Future<Either<Failure, double>> getTotalRevenueForYear(int year) async {
-    return await repository.getTotalRevenueForYear(year);
+  Future<Either<Failure, double>> getTotalRevenueForYear(
+      String clinicId, int year) async {
+    return await repository.getTotalRevenueForYear(clinicId, year);
   }
 
   /// Returns the total expenses (outwards) for a given year.
-  Future<Either<Failure, double>> getTotalExpensesForYear(int year) async {
-    return await repository.getTotalExpensesForYear(year);
+  Future<Either<Failure, double>> getTotalExpensesForYear(
+      String clinicId, int year) async {
+    return await repository.getTotalExpensesForYear(clinicId, year);
   }
 
   /// Returns the total revenue (inwards) for a given month and year.
   Future<Either<Failure, double>> getTotalRevenueForMonth(
-      int year, int month) async {
-    return await repository.getTotalRevenueForMonth(year, month);
+      String clinicId, int year, int month) async {
+    return await repository.getTotalRevenueForMonth(clinicId, year, month);
   }
 
   /// Returns the total expenses (outwards) for a given month and year.
   Future<Either<Failure, double>> getTotalExpensesForMonth(
-      int year, int month) async {
-    return await repository.getTotalExpensesForMonth(year, month);
+      String clinicId, int year, int month) async {
+    return await repository.getTotalExpensesForMonth(clinicId, year, month);
   }
 
   /// Returns the total for a given direction (inwards/outwards) and optional source.
   Future<Either<Failure, double>> getTotalByDirectionAndSource({
+    required String clinicId, // Added clinicId
     required TransactionDirection direction,
     TransactionSource? source,
     int? year,
     int? month,
   }) async {
     return await repository.getTotalByDirectionAndSource(
+      clinicId: clinicId, // Pass clinicId
       direction: direction,
       source: source,
       year: year,
@@ -122,8 +128,8 @@ class TransactionsUseCase {
 
   /// Deletes a transaction by its reference ID.
   Future<Either<Failure, void>> deleteTransactionByReferenceId(
-      String referenceId) async {
-    return await repository.deleteTransactionByReferenceId(referenceId);
+      String clinicId, String referenceId) async {
+    return await repository.deleteTransactionByReferenceId(
+        clinicId, referenceId);
   }
 }
-

--- a/lib/src/features/financials/transactions/presentation/bloc/transactions_bloc.dart
+++ b/lib/src/features/financials/transactions/presentation/bloc/transactions_bloc.dart
@@ -28,16 +28,6 @@ class TransactionsBloc extends Bloc<TransactionsEvent, TransactionsState> {
     on<LoadMoreTransactions>(_onLoadMoreTransactions);
     on<UpdateTransactionEvent>(_onUpdateTransaction);
     on<GetTransactionsCount>(_onGetTransactionsCount);
-
-    /// Initial event to fetch transactions when the bloc is created.
-    /// Used in [DashboardPage].
-    /// Adds a [GetTransactions] event to the bloc with the following parameters:
-    /// - [lastDocumentID]: `null`, indicating that transactions should be fetched from the beginning.
-    /// - [limit]: `3`, specifying the maximum number of transactions to retrieve.
-    add(GetTransactions(
-      lastDocumentID: null,
-      limit: 3,
-    ));
   }
 
   /// Handles fetching all financial transactions.
@@ -45,6 +35,7 @@ class TransactionsBloc extends Bloc<TransactionsEvent, TransactionsState> {
       GetTransactions event, Emitter<TransactionsState> emit) async {
     emit(TransactionsLoading(state.transactions));
     final failureOrTransactions = await _transactionsUseCase.getTransactions(
+      clinicId: event.clinicId,
       lastDocumentId: event.lastDocumentID,
       limit: event.limit,
     );
@@ -125,6 +116,7 @@ class TransactionsBloc extends Bloc<TransactionsEvent, TransactionsState> {
     emit(TransactionsLoading(state.transactions));
 
     final failureOrTransactions = await _transactionsUseCase.searchTransactions(
+      clinicId: event.clinicId,
       description: event.description,
     );
 
@@ -152,6 +144,7 @@ class TransactionsBloc extends Bloc<TransactionsEvent, TransactionsState> {
       emit(TransactionsLoaded(currentState.transactions, isLoadingMore: true));
       await Future.delayed(Duration(seconds: 1));
       final result = await _transactionsUseCase.getTransactions(
+        clinicId: event.clinicId,
         lastDocumentId: event.lastDocumentId,
         limit: event.limit,
       );
@@ -186,6 +179,7 @@ class TransactionsBloc extends Bloc<TransactionsEvent, TransactionsState> {
     emit(TransactionsLoading(state.transactions));
 
     final result = await _transactionsUseCase.getTransactionsByDate(
+      event.clinicId,
       event.date,
     );
     emit(result.fold(
@@ -208,12 +202,13 @@ class TransactionsBloc extends Bloc<TransactionsEvent, TransactionsState> {
   /// - [emit]: The function used to emit new [Tr]s.
   void _onGetTransactionsCount(
       GetTransactionsCount event, Emitter<TransactionsState> emit) async {
-    final failureOrCount = await _transactionsUseCase.getTransactionsCount();
+    final failureOrCount =
+        await _transactionsUseCase.getTransactionsCount(event.clinicId);
     emit(failureOrCount.fold(
       (failure) => TransactionsError(state.transactions,
           message: _mapFailureToMessage(failure)),
       (acc) {
-        debugPrint('Total transactions count: $count');
+        debugPrint('Total transactions count: $acc');
 
         emit(TransactionsCountLoaded(acc, state.transactions));
         return TransactionsLoaded(state.transactions);
@@ -258,4 +253,3 @@ class TransactionsBloc extends Bloc<TransactionsEvent, TransactionsState> {
     }
   }
 }
-

--- a/lib/src/features/financials/transactions/presentation/bloc/transactions_event.dart
+++ b/lib/src/features/financials/transactions/presentation/bloc/transactions_event.dart
@@ -9,21 +9,24 @@ abstract class TransactionsEvent extends Equatable {
 
 /// Event to fetch all financial transactions.
 class GetTransactions extends TransactionsEvent {
+  final String clinicId;
   final String? lastDocumentID;
   final int limit;
 
-  const GetTransactions({this.lastDocumentID, this.limit = 20});
+  const GetTransactions(
+      {required this.clinicId, this.lastDocumentID, this.limit = 20});
 
   @override
-  List<Object?> get props => [lastDocumentID, limit];
+  List<Object?> get props => [clinicId, lastDocumentID, limit];
 }
 
 /// Event to fetch all financial transactions.
 class SearchTransactions extends TransactionsEvent {
+  final String clinicId;
   final String description;
-  const SearchTransactions(this.description);
+  const SearchTransactions({required this.clinicId, required this.description});
   @override
-  List<Object?> get props => [description];
+  List<Object?> get props => [clinicId, description];
 }
 
 /// Event to add a new financial transaction.
@@ -47,24 +50,28 @@ class DeleteTransactionEvent extends TransactionsEvent {
 }
 
 class GetTransactionsByDate extends TransactionsEvent {
+  final String clinicId;
   final DateTime date;
 
   const GetTransactionsByDate({
+    required this.clinicId,
     required this.date,
   });
 
   @override
-  List<Object?> get props => [date];
+  List<Object?> get props => [clinicId, date];
 }
 
 class LoadMoreTransactions extends TransactionsEvent {
+  final String clinicId;
   final int? limit;
   final String? lastDocumentId;
 
-  const LoadMoreTransactions({this.lastDocumentId, this.limit});
+  const LoadMoreTransactions(
+      {required this.clinicId, this.lastDocumentId, this.limit});
 
   @override
-  List<Object?> get props => [lastDocumentId, limit];
+  List<Object?> get props => [clinicId, lastDocumentId, limit];
 }
 
 class UpdateTransactionEvent extends TransactionsEvent {
@@ -82,13 +89,13 @@ class UpdateTransactionEvent extends TransactionsEvent {
 /// This event can be dispatched to the [TransactionsBloc] to request
 /// the current number of transactions available.
 class GetTransactionsCount extends TransactionsEvent {
-  const GetTransactionsCount();
+  final String clinicId;
+  const GetTransactionsCount(this.clinicId);
 
   /// Returns a list of properties that will be used to determine whether two instances are equal.
   ///
   /// This override currently returns an empty list, meaning all instances will be considered equal
   /// unless this list is populated with relevant properties.
   @override
-  List<Object?> get props => [];
+  List<Object?> get props => [clinicId];
 }
-

--- a/lib/src/features/financials/transactions/presentation/pages/transactions_page.dart
+++ b/lib/src/features/financials/transactions/presentation/pages/transactions_page.dart
@@ -1,3 +1,4 @@
+import 'package:dr_copilot/src/core/app/notifiers/owner_notifier.dart';
 import 'package:dr_copilot/src/features/financials/transactions/domain/models/transaction_model.dart';
 import 'package:dr_copilot/src/features/financials/transactions/presentation/bloc/transactions_bloc.dart';
 import 'package:dr_copilot/src/features/financials/transactions/presentation/widgets/transaction_list_item.dart';
@@ -29,7 +30,10 @@ class _TransactionsPageState extends State<TransactionsPage> {
   int? _firestoreTransactionsCount;
 
   void _dispatchGetTransactionsCount() {
-    context.read<TransactionsBloc>().add(const GetTransactionsCount());
+    final clinicId = OwnerNotifier().clinicId;
+    if (clinicId != null) {
+      context.read<TransactionsBloc>().add(GetTransactionsCount(clinicId));
+    }
   }
 
   @override
@@ -38,7 +42,10 @@ class _TransactionsPageState extends State<TransactionsPage> {
     debugPrint('TransactionsPage: initState called');
     _scrollController.addListener(_onScroll);
     debugPrint('TransactionsPage: Scroll listener added');
-    context.read<TransactionsBloc>().add(const GetTransactions());
+    final clinicId = OwnerNotifier().clinicId;
+    if (clinicId != null) {
+      context.read<TransactionsBloc>().add(GetTransactions(clinicId: clinicId));
+    }
     _dispatchGetTransactionsCount();
   }
 
@@ -78,12 +85,16 @@ class _TransactionsPageState extends State<TransactionsPage> {
             debugPrint(
               'TransactionsPage: Dispatching LoadMoreTransactions event',
             );
-            context.read<TransactionsBloc>().add(
-                  LoadMoreTransactions(
-                    lastDocumentId: transactions.last.id,
-                    limit: 20,
-                  ),
-                );
+            final clinicId = OwnerNotifier().clinicId;
+            if (clinicId != null) {
+              context.read<TransactionsBloc>().add(
+                    LoadMoreTransactions(
+                      clinicId: clinicId,
+                      lastDocumentId: transactions.last.id,
+                      limit: 20,
+                    ),
+                  );
+            }
             Future.delayed(const Duration(seconds: 1), () {
               _canLoadMore = true;
             });
@@ -165,9 +176,13 @@ class _TransactionsPageState extends State<TransactionsPage> {
                               _selectedIndex =
                                   0; // Reset selection on new query
                             });
-                            context.read<TransactionsBloc>().add(
-                                  SearchTransactions(query),
-                                );
+                            final clinicId = OwnerNotifier().clinicId;
+                            if (clinicId != null) {
+                              context.read<TransactionsBloc>().add(
+                                    SearchTransactions(
+                                        description: query, clinicId: clinicId),
+                                  );
+                            }
                           },
                           onSubmitted: (_) {
                             _listFocusNode.requestFocus();
@@ -232,9 +247,12 @@ class _TransactionsPageState extends State<TransactionsPage> {
                           query = '';
                           _selectedDate = null;
                         });
-                        context.read<TransactionsBloc>().add(
-                              const GetTransactions(),
-                            );
+                        final clinicId = OwnerNotifier().clinicId;
+                        if (clinicId != null) {
+                          context.read<TransactionsBloc>().add(
+                                GetTransactions(clinicId: clinicId),
+                              );
+                        }
                       },
                     ),
                   ),
@@ -271,9 +289,14 @@ class _TransactionsPageState extends State<TransactionsPage> {
                                   _selectedDate = selectedDate;
                                 });
                                 if (!context.mounted) return;
-                                context.read<TransactionsBloc>().add(
-                                      GetTransactionsByDate(date: selectedDate),
-                                    );
+                                final clinicId = OwnerNotifier().clinicId;
+                                if (clinicId != null) {
+                                  context.read<TransactionsBloc>().add(
+                                        GetTransactionsByDate(
+                                            date: selectedDate,
+                                            clinicId: clinicId),
+                                      );
+                                }
                               }
                             },
                           ),
@@ -284,9 +307,12 @@ class _TransactionsPageState extends State<TransactionsPage> {
                                 setState(() {
                                   _selectedDate = null;
                                 });
-                                context.read<TransactionsBloc>().add(
-                                      const GetTransactions(),
-                                    );
+                                final clinicId = OwnerNotifier().clinicId;
+                                if (clinicId != null) {
+                                  context.read<TransactionsBloc>().add(
+                                        GetTransactions(clinicId: clinicId),
+                                      );
+                                }
                               },
                               icon: const Icon(Icons.close, size: 18),
                             ),

--- a/lib/src/features/invitations/data/remote/invitation_firebase_api.dart
+++ b/lib/src/features/invitations/data/remote/invitation_firebase_api.dart
@@ -3,11 +3,16 @@ import 'dart:developer';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:dr_copilot/src/core/error/exceptions.dart';
 import 'package:dr_copilot/src/features/invitations/domain/models/invitation_model.dart';
+import 'package:dr_copilot/src/core/app/notifiers/owner_notifier.dart';
+import 'package:dr_copilot/src/features/auth/domain/models/permission_enum.dart';
 
 class InvitationFirebaseApi {
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
 
   Future<void> createInvitation(InvitationModel invitation) async {
+    if (!OwnerNotifier().hasPermission(AppPermission.sendInvitation)) {
+      throw ServerException('Permission denied', 403);
+    }
     try {
       await _firestore
           .collection('user_invitations')
@@ -20,6 +25,9 @@ class InvitationFirebaseApi {
   }
 
   Future<List<InvitationModel>> getInvitationsByClinic(String clinicId) async {
+    if (!OwnerNotifier().hasPermission(AppPermission.viewInvitations)) {
+      throw ServerException('Permission denied', 403);
+    }
     try {
       final snapshot = await _firestore
           .collection('user_invitations')
@@ -42,6 +50,9 @@ class InvitationFirebaseApi {
   Future<List<InvitationModel>> getPendingInvitationsByClinic(
     String clinicId,
   ) async {
+    if (!OwnerNotifier().hasPermission(AppPermission.viewInvitations)) {
+      throw ServerException('Permission denied', 403);
+    }
     try {
       final snapshot = await _firestore
           .collection('user_invitations')
@@ -63,6 +74,9 @@ class InvitationFirebaseApi {
   }
 
   Future<void> deleteInvitation(String invitationId) async {
+    if (!OwnerNotifier().hasPermission(AppPermission.revokeInvitation)) {
+      throw ServerException('Permission denied', 403);
+    }
     try {
       await _firestore
           .collection('user_invitations')
@@ -75,6 +89,9 @@ class InvitationFirebaseApi {
   }
 
   Future<void> resendInvitation(String invitationId) async {
+    if (!OwnerNotifier().hasPermission(AppPermission.sendInvitation)) {
+      throw ServerException('Permission denied', 403);
+    }
     try {
       await _firestore.collection('user_invitations').doc(invitationId).update({
         'createdAt': Timestamp.fromDate(DateTime.now().toUtc()),
@@ -85,4 +102,3 @@ class InvitationFirebaseApi {
     }
   }
 }
-

--- a/lib/src/features/invitations/presentation/pages/create_invitation_page.dart
+++ b/lib/src/features/invitations/presentation/pages/create_invitation_page.dart
@@ -224,9 +224,9 @@ class _CreateInvitationPageState extends State<CreateInvitationPage> {
                 Text(
                   'Premium Feature',
                   style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                    fontWeight: FontWeight.bold,
-                    color: Theme.of(context).colorScheme.tertiary,
-                  ),
+                        fontWeight: FontWeight.bold,
+                        color: Theme.of(context).colorScheme.tertiary,
+                      ),
                 ),
                 const SizedBox(height: 8),
                 Text(
@@ -313,24 +313,24 @@ class _CreateInvitationPageState extends State<CreateInvitationPage> {
   }
 
   List<Step> getSteps() => [
-    Step(
-      title: Text('recipient'.tr()),
-      content: _buildEmailSelectionSection(),
-      isActive: _currentStep >= 0,
-      state: _currentStep > 0 ? StepState.complete : StepState.indexed,
-    ),
-    Step(
-      title: Text('assignRole'.tr()),
-      content: _buildRolesSection(),
-      isActive: _currentStep >= 1,
-      state: _currentStep > 1 ? StepState.complete : StepState.indexed,
-    ),
-    Step(
-      title: Text('review'.tr()),
-      content: _buildReviewSection(),
-      isActive: _currentStep >= 2,
-    ),
-  ];
+        Step(
+          title: Text('recipient'.tr()),
+          content: _buildEmailSelectionSection(),
+          isActive: _currentStep >= 0,
+          state: _currentStep > 0 ? StepState.complete : StepState.indexed,
+        ),
+        Step(
+          title: Text('assignRole'.tr()),
+          content: _buildRolesSection(),
+          isActive: _currentStep >= 1,
+          state: _currentStep > 1 ? StepState.complete : StepState.indexed,
+        ),
+        Step(
+          title: Text('review'.tr()),
+          content: _buildReviewSection(),
+          isActive: _currentStep >= 2,
+        ),
+      ];
 
   Widget _buildReviewSection() {
     final String email = _useManualEntry
@@ -613,7 +613,6 @@ class _CreateInvitationPageState extends State<CreateInvitationPage> {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         ...AppRole.values.map((role) {
-          if (role == AppRole.superAdmin) return const SizedBox.shrink();
           return RadioListTile<AppRole>(
             title: Text(_getRoleDisplayName(role)),
             subtitle: Text(
@@ -770,6 +769,12 @@ class _CreateInvitationPageState extends State<CreateInvitationPage> {
         return 'Allows access to billing, invoices, and financial reports.';
       case AppPermission.manageInvoices:
         return 'Allows creating and modifying invoices and payments.';
+      case AppPermission.addFinancialEntry:
+        return 'Allows adding new financial records (invoices, bills, transactions).';
+      case AppPermission.editFinancialEntry:
+        return 'Allows editing existing financial records.';
+      case AppPermission.deleteFinancialEntry:
+        return 'Allows deleting financial records.';
 
       // Copilot chat
       case AppPermission.useCopilot:
@@ -799,6 +804,34 @@ class _CreateInvitationPageState extends State<CreateInvitationPage> {
       case AppPermission.manageSettings:
         return 'Allows managing all settings.';
 
+      // Medical Files
+      case AppPermission.viewMedicalFiles:
+        return 'Allows viewing medical files.';
+      case AppPermission.addMedicalFile:
+        return 'Allows uploading or adding new medical files.';
+      case AppPermission.editMedicalFile:
+        return 'Allows editing medical file details.';
+      case AppPermission.deleteMedicalFile:
+        return 'Allows deleting medical files.';
+
+      // Medications
+      case AppPermission.viewMedications:
+        return 'Allows viewing patient medications.';
+      case AppPermission.addMedication:
+        return 'Allows prescribing or adding medications.';
+      case AppPermission.editMedication:
+        return 'Allows editing medication details.';
+      case AppPermission.deleteMedication:
+        return 'Allows removing medications.';
+
+      // Recycle Bin
+      case AppPermission.viewRecycleBin:
+        return 'Allows accessing the recycle bin.';
+      case AppPermission.restoreRecycleBinItem:
+        return 'Allows restoring deleted items.';
+      case AppPermission.permanentDeleteRecycleBinItem:
+        return 'Allows permanently deleting items.';
+
       // Admin
       case AppPermission.manageStaff:
         return 'Allows managing staff members.';
@@ -814,6 +847,36 @@ class _CreateInvitationPageState extends State<CreateInvitationPage> {
         return 'Allows generating and viewing detailed clinic reports.';
       case AppPermission.viewCharts:
         return 'Allows viewing data visualizations and performance charts.';
+
+      // Clinical Reports
+      case AppPermission.viewClinicalReports:
+        return 'Allows viewing clinical reports.';
+      case AppPermission.addClinicalReport:
+        return 'Allows creating new clinical reports.';
+      case AppPermission.editClinicalReport:
+        return 'Allows editing existing clinical reports.';
+      case AppPermission.deleteClinicalReport:
+        return 'Allows deleting clinical reports.';
+
+      // Doctors
+      case AppPermission.viewDoctors:
+        return 'Allows viewing the doctors directory.';
+      case AppPermission.manageDoctors:
+        return 'Allows adding, collecting, or removing doctors.';
+
+      // Invitations
+      case AppPermission.viewInvitations:
+        return 'Allows viewing pending and sent invitations.';
+      case AppPermission.sendInvitation:
+        return 'Allows sending new invitations to staff or doctors.';
+      case AppPermission.revokeInvitation:
+        return 'Allows revoking or deleting invitations.';
+
+      // Subscription
+      case AppPermission.viewSubscription:
+        return 'Allows viewing billing and subscription details.';
+      case AppPermission.manageSubscription:
+        return 'Allows upgrading or changing the subscription plan.';
 
       // Help/Support
       case AppPermission.viewHelp:
@@ -837,4 +900,3 @@ class _CreateInvitationPageState extends State<CreateInvitationPage> {
     }
   }
 }
-

--- a/lib/src/features/invitations/presentation/pages/invitations_page.dart
+++ b/lib/src/features/invitations/presentation/pages/invitations_page.dart
@@ -23,10 +23,11 @@ class InvitationsPage extends StatelessWidget {
       create: (context) => sl<InvitationBloc>()..add(LoadInvitations(clinicId)),
       child: FutureBuilder<({UserModel? user, bool isAdmin})>(
         future: () async {
-          final user = await sl<AuthUseCase>().getCurrentUser();
-          final isAdmin = user != null
-              ? await user.isAdminInClinic(clinicId)
-              : false;
+          final userResult = await sl<AuthUseCase>().getCurrentUser();
+          final user = userResult.fold((l) => null, (r) => r);
+
+          final isAdmin =
+              user != null ? await user.isAdminInClinic(clinicId) : false;
 
           // Debug logging
           if (user != null) {
@@ -91,8 +92,8 @@ class InvitationsPage extends StatelessWidget {
                   return RefreshIndicator(
                     onRefresh: () async {
                       context.read<InvitationBloc>().add(
-                        LoadInvitations(clinicId),
-                      );
+                            LoadInvitations(clinicId),
+                          );
                     },
                     child: ListView.builder(
                       itemCount: state.invitations.length,
@@ -104,8 +105,8 @@ class InvitationsPage extends StatelessWidget {
                             // Only admins can delete
                             if (isAdmin) {
                               context.read<InvitationBloc>().add(
-                                DeleteInvitation(invitation.id),
-                              );
+                                    DeleteInvitation(invitation.id),
+                                  );
                             } else {
                               ScaffoldMessenger.of(context).showSnackBar(
                                 SnackBar(
@@ -118,8 +119,8 @@ class InvitationsPage extends StatelessWidget {
                             // Only admins can resend
                             if (isAdmin) {
                               context.read<InvitationBloc>().add(
-                                ResendInvitation(invitation.id),
-                              );
+                                    ResendInvitation(invitation.id),
+                                  );
                             } else {
                               ScaffoldMessenger.of(context).showSnackBar(
                                 SnackBar(
@@ -142,4 +143,3 @@ class InvitationsPage extends StatelessWidget {
     );
   }
 }
-

--- a/lib/src/features/medical_files/data/repositories/medical_file_repository.dart
+++ b/lib/src/features/medical_files/data/repositories/medical_file_repository.dart
@@ -6,6 +6,8 @@ import 'package:dr_copilot/src/features/medical_files/domain/models/medical_file
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:universal_io/io.dart';
 import 'package:uuid/uuid.dart';
+import 'package:dr_copilot/src/core/app/notifiers/owner_notifier.dart';
+import 'package:dr_copilot/src/features/auth/domain/models/permission_enum.dart';
 
 class MedicalFileRepository {
   final FirebaseFirestore _firestore;
@@ -14,13 +16,16 @@ class MedicalFileRepository {
   MedicalFileRepository({
     FirebaseFirestore? firestore,
     FirebaseStorage? storage,
-  }) : _firestore = firestore ?? FirebaseFirestore.instance,
-       _storage = storage ?? FirebaseStorage.instance;
+  })  : _firestore = firestore ?? FirebaseFirestore.instance,
+        _storage = storage ?? FirebaseStorage.instance;
 
   Future<Either<Failure, String>> uploadFile({
     required File file,
     required String patientId,
   }) async {
+    if (!OwnerNotifier().hasPermission(AppPermission.addMedicalFile)) {
+      return Left(ServerFailure('Permission denied', 403));
+    }
     try {
       // 1. Validation
       final length = await file.length();
@@ -53,6 +58,9 @@ class MedicalFileRepository {
   Future<Either<Failure, MedicalFileModel>> addMedicalFile(
     MedicalFileModel medicalFile,
   ) async {
+    if (!OwnerNotifier().hasPermission(AppPermission.addMedicalFile)) {
+      return Left(ServerFailure('Permission denied', 403));
+    }
     try {
       await _firestore
           .collection('medical_files')
@@ -67,6 +75,9 @@ class MedicalFileRepository {
   Future<Either<Failure, List<MedicalFileModel>>> getMedicalFilesForPatient(
     String patientId,
   ) async {
+    if (!OwnerNotifier().hasPermission(AppPermission.viewMedicalFiles)) {
+      return Left(ServerFailure('Permission denied', 403));
+    }
     try {
       final snapshot = await _firestore
           .collection('medical_files')
@@ -89,6 +100,9 @@ class MedicalFileRepository {
   Future<Either<Failure, void>> deleteMedicalFile(
     MedicalFileModel medicalFile,
   ) async {
+    if (!OwnerNotifier().hasPermission(AppPermission.deleteMedicalFile)) {
+      return Left(ServerFailure('Permission denied', 403));
+    }
     try {
       // 1. Delete from Firestore
       await _firestore.collection('medical_files').doc(medicalFile.id).delete();
@@ -109,4 +123,3 @@ class MedicalFileRepository {
     }
   }
 }
-

--- a/lib/src/features/medical_files/domain/models/medical_file_model.g.dart
+++ b/lib/src/features/medical_files/domain/models/medical_file_model.g.dart
@@ -35,4 +35,3 @@ Map<String, dynamic> _$MedicalFileModelToJson(MedicalFileModel instance) =>
       'metadata': instance.metadata,
       'createdAt': instance.createdAt.toIso8601String(),
     };
-

--- a/lib/src/features/medications/data/repositories/medication_repository.dart
+++ b/lib/src/features/medications/data/repositories/medication_repository.dart
@@ -7,19 +7,24 @@ import 'package:dr_copilot/src/core/error/failures.dart';
 import 'package:dr_copilot/src/features/medications/domain/models/medication_model.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:uuid/uuid.dart';
+import 'package:dr_copilot/src/core/app/notifiers/owner_notifier.dart';
+import 'package:dr_copilot/src/features/auth/domain/models/permission_enum.dart';
 
 class MedicationRepository {
   final FirebaseFirestore _firestore;
   final FirebaseStorage _storage;
 
   MedicationRepository({FirebaseFirestore? firestore, FirebaseStorage? storage})
-    : _firestore = firestore ?? FirebaseFirestore.instance,
-      _storage = storage ?? FirebaseStorage.instance;
+      : _firestore = firestore ?? FirebaseFirestore.instance,
+        _storage = storage ?? FirebaseStorage.instance;
 
   Future<Either<Failure, String>> uploadPrescription({
     required File file,
     required String patientId,
   }) async {
+    if (!OwnerNotifier().hasPermission(AppPermission.addMedication)) {
+      return Left(ServerFailure('Permission denied', 403));
+    }
     try {
       final length = await file.length();
       if (length > 20 * 1024 * 1024) {
@@ -49,6 +54,9 @@ class MedicationRepository {
   Future<Either<Failure, MedicationModel>> addMedication(
     MedicationModel medication,
   ) async {
+    if (!OwnerNotifier().hasPermission(AppPermission.addMedication)) {
+      return Left(ServerFailure('Permission denied', 403));
+    }
     try {
       await _firestore
           .collection('medications')
@@ -63,6 +71,9 @@ class MedicationRepository {
   Future<Either<Failure, List<MedicationModel>>> getMedicationsForPatient(
     String patientId,
   ) async {
+    if (!OwnerNotifier().hasPermission(AppPermission.viewMedications)) {
+      return Left(ServerFailure('Permission denied', 403));
+    }
     try {
       final snapshot = await _firestore
           .collection('medications')
@@ -85,6 +96,9 @@ class MedicationRepository {
   Future<Either<Failure, void>> deleteMedication(
     MedicationModel medication,
   ) async {
+    if (!OwnerNotifier().hasPermission(AppPermission.deleteMedication)) {
+      return Left(ServerFailure('Permission denied', 403));
+    }
     try {
       await _firestore.collection('medications').doc(medication.id).delete();
 
@@ -100,4 +114,3 @@ class MedicationRepository {
     }
   }
 }
-

--- a/lib/src/features/medications/domain/models/medication_model.g.dart
+++ b/lib/src/features/medications/domain/models/medication_model.g.dart
@@ -37,4 +37,3 @@ Map<String, dynamic> _$MedicationModelToJson(MedicationModel instance) =>
       'fileUrl': instance.fileUrl,
       'createdAt': instance.createdAt.toIso8601String(),
     };
-

--- a/lib/src/features/navigation_side/domain/entities/destination.dart
+++ b/lib/src/features/navigation_side/domain/entities/destination.dart
@@ -78,8 +78,8 @@ enum Destination {
   ),
 
   // Team Collaboration
-  teamChat(NavItemModel('messages', Icons.chat), 'Messages'),
-  teams(NavItemModel('teams', Icons.groups), 'Manage your teams'),
+  teamChat(NavItemModel('messages', Icons.chat_outlined), 'Messages'),
+  teams(NavItemModel('teams', Icons.groups_outlined), 'Manage your teams'),
 
   // Additional (not currently in menu)
   chat(NavItemModel('chat', Icons.chat_bubble_outline), 'Open chat'),
@@ -92,4 +92,3 @@ enum Destination {
   final String message; // Tooltip or explanation for the destination
   const Destination(this.model, this.message);
 }
-

--- a/lib/src/features/navigation_side/presentation/widgets/navigation_side.dart
+++ b/lib/src/features/navigation_side/presentation/widgets/navigation_side.dart
@@ -383,6 +383,37 @@ class _NavigationSideState extends State<NavigationSide> {
                                                         ),
                                                   ),
                                                 ),
+                                                const SizedBox(width: 8),
+                                                Container(
+                                                  padding: const EdgeInsets
+                                                      .symmetric(
+                                                      horizontal: 6,
+                                                      vertical: 2),
+                                                  decoration: BoxDecoration(
+                                                    color: Colors.orange
+                                                        .withOpacity(0.2),
+                                                    borderRadius:
+                                                        BorderRadius.circular(
+                                                            4),
+                                                    border: Border.all(
+                                                        color: Colors.orange,
+                                                        width: 1),
+                                                  ),
+                                                  child: Text(
+                                                    'BETA',
+                                                    style: Theme.of(context)
+                                                        .textTheme
+                                                        .labelSmall
+                                                        ?.copyWith(
+                                                          color: Colors
+                                                              .orange[800],
+                                                          fontWeight:
+                                                              FontWeight.bold,
+                                                          fontSize: 10,
+                                                          letterSpacing: 0.5,
+                                                        ),
+                                                  ),
+                                                ),
                                               ],
                                             ),
                                           );
@@ -481,7 +512,8 @@ class _NavigationSideState extends State<NavigationSide> {
                                                             url,
                                                           ) =>
                                                               const Icon(
-                                                            Icons.person_pin,
+                                                            Icons
+                                                                .account_circle_outlined,
                                                           ),
                                                           errorWidget: (
                                                             context,

--- a/lib/src/features/notifications/domain/models/notification_model.g.dart
+++ b/lib/src/features/notifications/domain/models/notification_model.g.dart
@@ -6,21 +6,22 @@ part of 'notification_model.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-NotificationModel _$NotificationModelFromJson(
-  Map<String, dynamic> json,
-) => NotificationModel(
-  id: json['id'] as String,
-  userId: json['userId'] as String,
-  title: json['title'] as String,
-  message: json['message'] as String,
-  type: $enumDecode(_$NotificationTypeEnumMap, json['type']),
-  isRead: json['isRead'] as bool? ?? false,
-  createdAt: NotificationModel._timestampFromJson(json['createdAt']),
-  actionUrl: json['actionUrl'] as String?,
-  metadata: json['metadata'] as Map<String, dynamic>?,
-  sender: NotificationSender.fromJson(json['sender'] as Map<String, dynamic>),
-  target: NotificationTarget.fromJson(json['target'] as Map<String, dynamic>),
-);
+NotificationModel _$NotificationModelFromJson(Map<String, dynamic> json) =>
+    NotificationModel(
+      id: json['id'] as String,
+      userId: json['userId'] as String,
+      title: json['title'] as String,
+      message: json['message'] as String,
+      type: $enumDecode(_$NotificationTypeEnumMap, json['type']),
+      isRead: json['isRead'] as bool? ?? false,
+      createdAt: NotificationModel._timestampFromJson(json['createdAt']),
+      actionUrl: json['actionUrl'] as String?,
+      metadata: json['metadata'] as Map<String, dynamic>?,
+      sender:
+          NotificationSender.fromJson(json['sender'] as Map<String, dynamic>),
+      target:
+          NotificationTarget.fromJson(json['target'] as Map<String, dynamic>),
+    );
 
 Map<String, dynamic> _$NotificationModelToJson(NotificationModel instance) =>
     <String, dynamic>{
@@ -71,9 +72,7 @@ NotificationTarget _$NotificationTargetFromJson(Map<String, dynamic> json) =>
     NotificationTarget(
       type: $enumDecode(_$NotificationTargetTypeEnumMap, json['type']),
       targetRoles: _$JsonConverterFromJson<List<dynamic>, List<AppRole>>(
-        json['targetRoles'],
-        const RoleListJsonConverter().fromJson,
-      ),
+          json['targetRoles'], const RoleListJsonConverter().fromJson),
       ownerId: json['ownerId'] as String?,
       clinicIds: (json['clinicIds'] as List<dynamic>?)
           ?.map((e) => e as String)
@@ -85,9 +84,7 @@ Map<String, dynamic> _$NotificationTargetToJson(NotificationTarget instance) =>
     <String, dynamic>{
       'type': _$NotificationTargetTypeEnumMap[instance.type]!,
       'targetRoles': _$JsonConverterToJson<List<dynamic>, List<AppRole>>(
-        instance.targetRoles,
-        const RoleListJsonConverter().toJson,
-      ),
+          instance.targetRoles, const RoleListJsonConverter().toJson),
       'ownerId': instance.ownerId,
       'clinicIds': instance.clinicIds,
       'teamId': instance.teamId,
@@ -107,10 +104,11 @@ const _$NotificationTargetTypeEnumMap = {
 Value? _$JsonConverterFromJson<Json, Value>(
   Object? json,
   Value? Function(Json json) fromJson,
-) => json == null ? null : fromJson(json as Json);
+) =>
+    json == null ? null : fromJson(json as Json);
 
 Json? _$JsonConverterToJson<Json, Value>(
   Value? value,
   Json? Function(Value value) toJson,
-) => value == null ? null : toJson(value);
-
+) =>
+    value == null ? null : toJson(value);

--- a/lib/src/features/notifications/domain/models/notification_template.g.dart
+++ b/lib/src/features/notifications/domain/models/notification_template.g.dart
@@ -7,30 +7,32 @@ part of 'notification_template.dart';
 // **************************************************************************
 
 NotificationTemplate _$NotificationTemplateFromJson(
-  Map<String, dynamic> json,
-) => NotificationTemplate(
-  id: json['id'] as String,
-  title: json['title'] as String,
-  message: json['message'] as String,
-  type: $enumDecode(_$NotificationTypeEnumMap, json['type']),
-  sender: NotificationSender.fromJson(json['sender'] as Map<String, dynamic>),
-  target: NotificationTarget.fromJson(json['target'] as Map<String, dynamic>),
-  actionUrl: json['actionUrl'] as String?,
-  metadata: json['metadata'] as Map<String, dynamic>?,
-);
+        Map<String, dynamic> json) =>
+    NotificationTemplate(
+      id: json['id'] as String,
+      title: json['title'] as String,
+      message: json['message'] as String,
+      type: $enumDecode(_$NotificationTypeEnumMap, json['type']),
+      sender:
+          NotificationSender.fromJson(json['sender'] as Map<String, dynamic>),
+      target:
+          NotificationTarget.fromJson(json['target'] as Map<String, dynamic>),
+      actionUrl: json['actionUrl'] as String?,
+      metadata: json['metadata'] as Map<String, dynamic>?,
+    );
 
 Map<String, dynamic> _$NotificationTemplateToJson(
-  NotificationTemplate instance,
-) => <String, dynamic>{
-  'id': instance.id,
-  'title': instance.title,
-  'message': instance.message,
-  'type': _$NotificationTypeEnumMap[instance.type]!,
-  'sender': instance.sender,
-  'target': instance.target,
-  'actionUrl': instance.actionUrl,
-  'metadata': instance.metadata,
-};
+        NotificationTemplate instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'title': instance.title,
+      'message': instance.message,
+      'type': _$NotificationTypeEnumMap[instance.type]!,
+      'sender': instance.sender,
+      'target': instance.target,
+      'actionUrl': instance.actionUrl,
+      'metadata': instance.metadata,
+    };
 
 const _$NotificationTypeEnumMap = {
   NotificationType.appointment: 'appointment',
@@ -41,4 +43,3 @@ const _$NotificationTypeEnumMap = {
   NotificationType.report: 'report',
   NotificationType.alert: 'alert',
 };
-

--- a/lib/src/features/notifications/presentation/pages/admin_send_notification_page.dart
+++ b/lib/src/features/notifications/presentation/pages/admin_send_notification_page.dart
@@ -37,7 +37,7 @@ class _AdminSendNotificationPageState extends State<AdminSendNotificationPage> {
     super.initState();
     // Security Check: Only Admins can access this page
     final role = context.read<OwnerNotifier>().role;
-    if (role != AppRole.admin && role != AppRole.superAdmin) {
+    if (role != AppRole.admin) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('access_denied_admins_only'.tr())),
@@ -137,8 +137,7 @@ class _AdminSendNotificationPageState extends State<AdminSendNotificationPage> {
         targetRoles: _selectedTarget == NotificationTargetType.specificRoles
             ? _selectedRoles
             : null,
-        ownerId:
-            _selectedTarget == NotificationTargetType.ownerClinics ||
+        ownerId: _selectedTarget == NotificationTargetType.ownerClinics ||
                 _selectedTarget == NotificationTargetType.specificClinic
             ? _currentUser!.uid
             : null,
@@ -162,9 +161,9 @@ class _AdminSendNotificationPageState extends State<AdminSendNotificationPage> {
               SnackBar(
                 content: Text(
                   'notification_sent_to_users'.tr().replaceAll(
-                    '{count}',
-                    state.recipientCount.toString(),
-                  ),
+                        '{count}',
+                        state.recipientCount.toString(),
+                      ),
                 ),
                 backgroundColor: Colors.green,
               ),
@@ -316,17 +315,16 @@ class _AdminSendNotificationPageState extends State<AdminSendNotificationPage> {
         border: const OutlineInputBorder(),
         prefixIcon: const Icon(Icons.people),
       ),
-      items:
-          [
-            NotificationTargetType.ownerClinics,
-            NotificationTargetType.specificClinic,
-            NotificationTargetType.specificRoles,
-          ].map((type) {
-            return DropdownMenuItem(
-              value: type,
-              child: Text(_getTargetLabel(type)),
-            );
-          }).toList(),
+      items: [
+        NotificationTargetType.ownerClinics,
+        NotificationTargetType.specificClinic,
+        NotificationTargetType.specificRoles,
+      ].map((type) {
+        return DropdownMenuItem(
+          value: type,
+          child: Text(_getTargetLabel(type)),
+        );
+      }).toList(),
       onChanged: (value) {
         if (value != null) {
           setState(() {
@@ -396,9 +394,8 @@ class _AdminSendNotificationPageState extends State<AdminSendNotificationPage> {
             ..._userClinics.map((clinic) {
               return CheckboxListTile(
                 title: Text(clinic.name),
-                subtitle: clinic.location != null
-                    ? Text(clinic.location!)
-                    : null,
+                subtitle:
+                    clinic.location != null ? Text(clinic.location!) : null,
                 value: _selectedClinicIds.contains(clinic.id),
                 onChanged: (bool? value) {
                   setState(() {
@@ -473,8 +470,6 @@ class _AdminSendNotificationPageState extends State<AdminSendNotificationPage> {
 
   String _getRoleLabel(AppRole role) {
     switch (role) {
-      case AppRole.superAdmin:
-        return 'super_admin'.tr();
       case AppRole.admin:
         return 'admin'.tr();
       case AppRole.doctor:
@@ -488,4 +483,3 @@ class _AdminSendNotificationPageState extends State<AdminSendNotificationPage> {
     }
   }
 }
-

--- a/lib/src/features/notifications/presentation/pages/create_notification_page.dart
+++ b/lib/src/features/notifications/presentation/pages/create_notification_page.dart
@@ -63,27 +63,26 @@ class _CreateNotificationPageState extends State<CreateNotificationPage> {
   void _calculateAllowedTypes() {
     // Access OwnerNotifier to get current real-time permissions
     final ownerNotifier = context.read<OwnerNotifier>();
-    final permissions = ownerNotifier.permissions;
     final role = ownerNotifier.role;
 
     final allowed = <NotificationType>[];
     final allowedTargets = <NotificationTargetType>[];
 
     // 1. Determine Allowed Types based on Permissions
-    if (permissions.contains(AppPermission.sendNotificationMessage)) {
+    if (ownerNotifier.hasPermission(AppPermission.sendNotificationMessage)) {
       allowed.add(NotificationType.message);
     }
-    if (permissions.contains(AppPermission.sendNotificationAppointment)) {
+    if (ownerNotifier
+        .hasPermission(AppPermission.sendNotificationAppointment)) {
       allowed.add(NotificationType.appointment);
     }
-    if (permissions.contains(AppPermission.sendNotificationReminder)) {
+    if (ownerNotifier.hasPermission(AppPermission.sendNotificationReminder)) {
       allowed.add(NotificationType.reminder);
     }
 
     // Admin/Manager Types
     if (role == AppRole.admin ||
-        role == AppRole.superAdmin ||
-        permissions.contains(AppPermission.manageNotifications)) {
+        ownerNotifier.hasPermission(AppPermission.manageNotifications)) {
       allowed.add(NotificationType.system);
       allowed.add(NotificationType.alert);
       allowed.add(NotificationType.report);
@@ -92,8 +91,7 @@ class _CreateNotificationPageState extends State<CreateNotificationPage> {
 
     // 2. Determine Allowed Targets
     if (role == AppRole.admin ||
-        role == AppRole.superAdmin ||
-        permissions.contains(AppPermission.manageNotifications)) {
+        ownerNotifier.hasPermission(AppPermission.manageNotifications)) {
       // Admins can target everyone
       allowedTargets.addAll([
         NotificationTargetType.ownerClinics,
@@ -203,22 +201,16 @@ class _CreateNotificationPageState extends State<CreateNotificationPage> {
       message: _messageController.text,
       type: _selectedType!,
       sender: NotificationSender(
-        type:
-            (context.read<AuthBloc>().state is AuthSignedIn &&
-                (context.read<AuthBloc>().state as AuthSignedIn).user?.clinics
-                        ?.any((c) => c['role'] == AppRole.superAdmin.name) ==
-                    true)
-            ? NotificationSenderType.programmer
-            : NotificationSenderType.clinicOwner,
+        type: NotificationSenderType.clinicOwner,
         senderId: context.read<AuthBloc>().state is AuthSignedIn
             ? (context.read<AuthBloc>().state as AuthSignedIn).user?.uid ??
-                  'unknown_sender'
+                'unknown_sender'
             : 'unknown_sender',
         senderName: context.read<AuthBloc>().state is AuthSignedIn
             ? (context.read<AuthBloc>().state as AuthSignedIn)
-                      .user
-                      ?.displayName ??
-                  'Clinic Staff'
+                    .user
+                    ?.displayName ??
+                'Clinic Staff'
             : 'Clinic Staff',
       ),
       target: NotificationTarget(
@@ -229,8 +221,8 @@ class _CreateNotificationPageState extends State<CreateNotificationPage> {
         ownerId: _selectedTargetType == NotificationTargetType.ownerClinics
             // Auto-use current user ID as owner ID for simplicity and security
             ? (context.read<AuthBloc>().state is AuthSignedIn
-                  ? (context.read<AuthBloc>().state as AuthSignedIn).user?.uid
-                  : null)
+                ? (context.read<AuthBloc>().state as AuthSignedIn).user?.uid
+                : null)
             : null,
         clinicIds: _selectedTargetType == NotificationTargetType.specificClinic
             ? _selectedClinicIds
@@ -386,12 +378,11 @@ class _CreateNotificationPageState extends State<CreateNotificationPage> {
                   items: _actionOptions.entries
                       .where((entry) => entry.key != 'custom') // Hide custom
                       .map((entry) {
-                        return DropdownMenuItem(
-                          value: entry.key,
-                          child: Text(entry.key.toUpperCase()),
-                        );
-                      })
-                      .toList(),
+                    return DropdownMenuItem(
+                      value: entry.key,
+                      child: Text(entry.key.toUpperCase()),
+                    );
+                  }).toList(),
                   onChanged: (value) {
                     setState(() => _selectedAction = value!);
                   },
@@ -568,4 +559,3 @@ class _CreateNotificationPageState extends State<CreateNotificationPage> {
     );
   }
 }
-

--- a/lib/src/features/notifications/presentation/pages/debug_notification_sender_page.dart
+++ b/lib/src/features/notifications/presentation/pages/debug_notification_sender_page.dart
@@ -152,9 +152,8 @@ class _DebugNotificationSenderPageState
     });
 
     try {
-      final usersSnapshot = await FirebaseFirestore.instance
-          .collection('users')
-          .get();
+      final usersSnapshot =
+          await FirebaseFirestore.instance.collection('users').get();
 
       final batch = FirebaseFirestore.instance.batch();
       final now = DateTime.now();
@@ -178,9 +177,8 @@ class _DebugNotificationSenderPageState
           ),
         );
 
-        final docRef = FirebaseFirestore.instance
-            .collection('notifications')
-            .doc();
+        final docRef =
+            FirebaseFirestore.instance.collection('notifications').doc();
         batch.set(docRef, notification.toJson());
       }
 
@@ -239,7 +237,8 @@ class _DebugNotificationSenderPageState
                         padding: const EdgeInsets.all(16.0),
                         child: Row(
                           children: [
-                            const Icon(Icons.warning, color: Colors.orange),
+                            const Icon(Icons.warning_amber_rounded,
+                                color: Colors.orange),
                             const SizedBox(width: 12),
                             Expanded(
                               child: Text(
@@ -301,31 +300,31 @@ class _DebugNotificationSenderPageState
                         Color color;
                         switch (type) {
                           case NotificationType.appointment:
-                            icon = Icons.calendar_today;
+                            icon = Icons.calendar_today_outlined;
                             color = Colors.purple;
                             break;
                           case NotificationType.message:
-                            icon = Icons.message;
+                            icon = Icons.chat_bubble_outline;
                             color = Colors.indigo;
                             break;
                           case NotificationType.reminder:
-                            icon = Icons.alarm;
+                            icon = Icons.alarm_outlined;
                             color = Colors.teal;
                             break;
                           case NotificationType.system:
-                            icon = Icons.info;
+                            icon = Icons.info_outline;
                             color = Colors.blue;
                             break;
                           case NotificationType.payment:
-                            icon = Icons.payment;
+                            icon = Icons.payment_outlined;
                             color = Colors.green;
                             break;
                           case NotificationType.report:
-                            icon = Icons.assessment;
+                            icon = Icons.assessment_outlined;
                             color = Colors.orange;
                             break;
                           case NotificationType.alert:
-                            icon = Icons.warning;
+                            icon = Icons.warning_amber_rounded;
                             color = Colors.red;
                             break;
                         }
@@ -392,11 +391,11 @@ class _DebugNotificationSenderPageState
                     // Quick Templates
                     ExpansionTile(
                       title: Text('quickTemplates'.tr()),
-                      leading: const Icon(Icons.auto_awesome),
+                      leading: const Icon(Icons.auto_awesome_outlined),
                       children: [
                         ListTile(
                           leading: const Icon(
-                            Icons.calendar_today,
+                            Icons.calendar_today_outlined,
                             color: Colors.purple,
                           ),
                           title: Text('appointmentReminder'.tr()),
@@ -410,7 +409,7 @@ class _DebugNotificationSenderPageState
                         ),
                         ListTile(
                           leading: const Icon(
-                            Icons.medication,
+                            Icons.medication_outlined,
                             color: Colors.red,
                           ),
                           title: Text('medicationReminder'.tr()),
@@ -467,7 +466,7 @@ class _DebugNotificationSenderPageState
                     const SizedBox(height: 12),
                     OutlinedButton.icon(
                       onPressed: _sendToAllUsers,
-                      icon: const Icon(Icons.group),
+                      icon: const Icon(Icons.group_outlined),
                       label: Text('sendToAllUsers'.tr()),
                       style: OutlinedButton.styleFrom(
                         padding: const EdgeInsets.all(16),
@@ -482,4 +481,3 @@ class _DebugNotificationSenderPageState
     );
   }
 }
-

--- a/lib/src/features/patients/data/remote/patient_firebase_api.dart
+++ b/lib/src/features/patients/data/remote/patient_firebase_api.dart
@@ -33,6 +33,9 @@ class PatientFirebaseApi extends AbstractPatientsRepository {
   }) async {
     try {
       final user = FirebaseAuth.instance.currentUser;
+      if (clinicId == null) {
+        return Left(ServerFailure('No clinic ID found', 403));
+      }
       if (user != null) {
         Query queryRef =
             _patientsCollection.where('clinicId', isEqualTo: clinicId);
@@ -89,6 +92,9 @@ class PatientFirebaseApi extends AbstractPatientsRepository {
   Future<Either<Failure, PatientModel>> addPatient(PatientModel patient) async {
     try {
       final user = FirebaseAuth.instance.currentUser;
+      if (clinicId == null) {
+        return Left(ServerFailure('No clinic ID found', 403));
+      }
       if (user != null) {
         final data = patient.toJson();
         data.remove('id'); // Exclude the `id` field from the document data
@@ -96,6 +102,7 @@ class PatientFirebaseApi extends AbstractPatientsRepository {
           ...data,
           'userId': user.uid,
           "createdBy": user.uid,
+          'clinicId': clinicId,
         });
         final createdPatient = patient.copyWith(
           id: docRef.id, // Assign the generated document ID
@@ -173,6 +180,9 @@ class PatientFirebaseApi extends AbstractPatientsRepository {
   }) async {
     try {
       final user = FirebaseAuth.instance.currentUser;
+      if (clinicId == null) {
+        return Left(ServerFailure('No clinic ID found', 403));
+      }
       if (user != null) {
         Query queryRef =
             _patientsCollection.where('clinicId', isEqualTo: clinicId);
@@ -235,6 +245,9 @@ class PatientFirebaseApi extends AbstractPatientsRepository {
       {DocumentSnapshot? lastDocument, int limit = 20}) async {
     try {
       final user = FirebaseAuth.instance.currentUser;
+      if (clinicId == null) {
+        return Left(ServerFailure('No clinic ID found', 403));
+      }
       if (user != null) {
         final startOfMonth = DateTime(year, month, 1);
         final endOfMonth = DateTime(year, month + 1, 1);
@@ -315,6 +328,9 @@ class PatientFirebaseApi extends AbstractPatientsRepository {
     }
     try {
       final user = FirebaseAuth.instance.currentUser;
+      if (clinicId == null) {
+        return Left(ServerFailure('No clinic ID found', 403));
+      }
       if (user != null) {
         Query queryRef =
             _patientsCollection.where('clinicId', isEqualTo: clinicId);
@@ -355,6 +371,9 @@ class PatientFirebaseApi extends AbstractPatientsRepository {
     }
     try {
       final user = _auth.currentUser;
+      if (clinicId == null) {
+        return Left(ServerFailure('No clinic ID found', 403));
+      }
       if (user != null) {
         Query query =
             _patientsCollection.where('clinicId', isEqualTo: clinicId);
@@ -373,5 +392,83 @@ class PatientFirebaseApi extends AbstractPatientsRepository {
       return Left(ServerFailure(e.toString(), 404));
     }
   }
-}
 
+  /// Gets all deleted patients (where deletedAt is not null).
+  @override
+  Future<Either<Failure, List<PatientModel>>> getDeletedPatients() async {
+    if (!await _isAuthenticated()) {
+      debugPrint('User not authenticated');
+      return Left(ServerFailure('User not authenticated', 401));
+    }
+    try {
+      final user = FirebaseAuth.instance.currentUser;
+      if (clinicId == null) {
+        return Left(ServerFailure('No clinic ID found', 403));
+      }
+      if (user != null) {
+        Query queryRef = _patientsCollection
+            .where('clinicId', isEqualTo: clinicId)
+            .where('deletedAt', isNull: false);
+
+        // Filter by createdBy if the user does not have permission to view all patients
+        if (!OwnerNotifier().hasPermission(AppPermission.viewAllPatients)) {
+          queryRef = queryRef.where('createdBy', isEqualTo: user.uid);
+        }
+
+        final snapshot =
+            await queryRef.orderBy('deletedAt', descending: true).get();
+
+        List<PatientModel> patients = snapshot.docs.map((doc) {
+          final data = doc.data() as Map<String, dynamic>?;
+          if (data == null) {
+            throw Exception('Document data is null');
+          }
+          return PatientModel.fromJson({
+            ...data,
+            'id': doc.id,
+          });
+        }).toList();
+
+        return Right(patients);
+      }
+      return Left(ServerFailure('User not authenticated', 401));
+    } catch (e) {
+      debugPrint('Error in getDeletedPatients: $e');
+      return Left(ServerFailure(e.toString(), 404));
+    }
+  }
+
+  /// Restores a deleted patient by setting deletedAt to null.
+  @override
+  Future<Either<Failure, void>> restorePatient(String id) async {
+    if (!await _isAuthenticated()) {
+      debugPrint('User not authenticated');
+      return Left(ServerFailure('User not authenticated', 401));
+    }
+    try {
+      await _patientsCollection.doc(id).update({
+        'deletedAt': null,
+      });
+      return const Right(null);
+    } catch (e) {
+      debugPrint('Error restoring patient: $e');
+      return Left(ServerFailure(e.toString(), 404));
+    }
+  }
+
+  /// Permanently deletes a patient from Firestore.
+  @override
+  Future<Either<Failure, void>> permanentlyDeletePatient(String id) async {
+    if (!await _isAuthenticated()) {
+      debugPrint('User not authenticated');
+      return Left(ServerFailure('User not authenticated', 401));
+    }
+    try {
+      await _patientsCollection.doc(id).delete();
+      return const Right(null);
+    } catch (e) {
+      debugPrint('Error permanently deleting patient: $e');
+      return Left(ServerFailure(e.toString(), 404));
+    }
+  }
+}

--- a/lib/src/features/patients/data/repositories/patients_repo_impl.dart
+++ b/lib/src/features/patients/data/repositories/patients_repo_impl.dart
@@ -12,7 +12,8 @@ class PatientsRepositoryImpl extends AbstractPatientsRepository {
 
   /// Fetches a list of patients with pagination.
   @override
-  Future<Either<Failure, Tuple2<List<PatientModel>, DocumentSnapshot?>>> getPatients({
+  Future<Either<Failure, Tuple2<List<PatientModel>, DocumentSnapshot?>>>
+      getPatients({
     String? lastDocumentId,
     int? limit,
   }) {
@@ -75,10 +76,28 @@ class PatientsRepositoryImpl extends AbstractPatientsRepository {
 
   /// Fetches patients by a specific date.
   @override
-  Future<Either<Failure, List<PatientModel>>> getPatientsByDate(int year, int month,
+  Future<Either<Failure, List<PatientModel>>> getPatientsByDate(
+      int year, int month,
       {DocumentSnapshot? lastDocument, int limit = 20}) {
     return api.getPatientsByDate(year, month,
         lastDocument: lastDocument, limit: limit);
   }
-}
 
+  /// Gets all deleted patients (where deletedAt is not null).
+  @override
+  Future<Either<Failure, List<PatientModel>>> getDeletedPatients() {
+    return api.getDeletedPatients();
+  }
+
+  /// Restores a deleted patient by setting deletedAt to null.
+  @override
+  Future<Either<Failure, void>> restorePatient(String id) {
+    return api.restorePatient(id);
+  }
+
+  /// Permanently deletes a patient from Firestore.
+  @override
+  Future<Either<Failure, void>> permanentlyDeletePatient(String id) {
+    return api.permanentlyDeletePatient(id);
+  }
+}

--- a/lib/src/features/patients/domain/models/patient_model.g.dart
+++ b/lib/src/features/patients/domain/models/patient_model.g.dart
@@ -7,24 +7,24 @@ part of 'patient_model.dart';
 // **************************************************************************
 
 PatientModel _$PatientModelFromJson(Map<String, dynamic> json) => PatientModel(
-  id: json['id'] as String,
-  name: json['name'] as String,
-  age: (json['age'] as num?)?.toInt(),
-  gender: json['gender'] as String?,
-  address: json['address'] as String?,
-  ownerId: json['ownerId'] as String,
-  clinicId: json['clinicId'] as String,
-  phoneNumber: json['phoneNumber'] as String?,
-  alternativePhoneNumber: json['alternativePhoneNumber'] as String?,
-  treatingDoctor: json['treatingDoctor'] as String?,
-  occupation: json['occupation'] as String?,
-  createdAt: const TimestampConverter().fromJson(json['createdAt']),
-  updatedAt: const TimestampConverter().fromJson(json['updatedAt']),
-  createdBy: json['createdBy'] as String?,
-  updatedBy: json['updatedBy'] as String?,
-  deletedBy: json['deletedBy'] as String?,
-  deletedAt: const TimestampConverter().fromJson(json['deletedAt']),
-);
+      id: json['id'] as String,
+      name: json['name'] as String,
+      age: (json['age'] as num?)?.toInt(),
+      gender: json['gender'] as String?,
+      address: json['address'] as String?,
+      ownerId: json['ownerId'] as String,
+      clinicId: json['clinicId'] as String,
+      phoneNumber: json['phoneNumber'] as String?,
+      alternativePhoneNumber: json['alternativePhoneNumber'] as String?,
+      treatingDoctor: json['treatingDoctor'] as String?,
+      occupation: json['occupation'] as String?,
+      createdAt: const TimestampConverter().fromJson(json['createdAt']),
+      updatedAt: const TimestampConverter().fromJson(json['updatedAt']),
+      createdBy: json['createdBy'] as String?,
+      updatedBy: json['updatedBy'] as String?,
+      deletedBy: json['deletedBy'] as String?,
+      deletedAt: const TimestampConverter().fromJson(json['deletedAt']),
+    );
 
 Map<String, dynamic> _$PatientModelToJson(PatientModel instance) =>
     <String, dynamic>{
@@ -46,4 +46,3 @@ Map<String, dynamic> _$PatientModelToJson(PatientModel instance) =>
       'deletedBy': instance.deletedBy,
       'deletedAt': const TimestampConverter().toJson(instance.deletedAt),
     };
-

--- a/lib/src/features/patients/domain/repositories/abstract_patients_repository.dart
+++ b/lib/src/features/patients/domain/repositories/abstract_patients_repository.dart
@@ -6,7 +6,8 @@ import 'package:dr_copilot/src/features/patients/domain/models/patient_model.dar
 /// An abstract class that defines the repository for patient-related operations.
 abstract class AbstractPatientsRepository {
   /// Gets a list of patients with pagination.
-  Future<Either<Failure, Tuple2<List<PatientModel>, DocumentSnapshot?>>> getPatients({
+  Future<Either<Failure, Tuple2<List<PatientModel>, DocumentSnapshot?>>>
+      getPatients({
     String? lastDocumentId,
     int? limit,
   });
@@ -31,7 +32,8 @@ abstract class AbstractPatientsRepository {
   });
 
   /// Gets patients by a specific date.
-  Future<Either<Failure, List<PatientModel>>> getPatientsByDate(int year, int month,
+  Future<Either<Failure, List<PatientModel>>> getPatientsByDate(
+      int year, int month,
       {DocumentSnapshot? lastDocument, int limit = 20});
 
   /// Gets a single patient by their ID.
@@ -42,5 +44,13 @@ abstract class AbstractPatientsRepository {
 
   /// Gets the total count of patients in Firestore.
   Future<Either<Failure, int>> getPatientsCount();
-}
 
+  /// Gets all deleted patients (where deletedAt is not null).
+  Future<Either<Failure, List<PatientModel>>> getDeletedPatients();
+
+  /// Restores a deleted patient by setting deletedAt to null.
+  Future<Either<Failure, void>> restorePatient(String id);
+
+  /// Permanently deletes a patient from Firestore.
+  Future<Either<Failure, void>> permanentlyDeletePatient(String id);
+}

--- a/lib/src/features/patients/presentation/widgets/patients_view.dart
+++ b/lib/src/features/patients/presentation/widgets/patients_view.dart
@@ -3,8 +3,6 @@ import 'package:dr_copilot/src/features/patients/domain/models/patient_model.dar
 import 'package:dr_copilot/src/features/patients/presentation/widgets/patient_list_item.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
-import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 import 'package:dr_copilot/src/core/helper/screen_size_helper.dart';
 

--- a/lib/src/features/recycle_bin/presentation/bloc/recycle_bin_bloc.dart
+++ b/lib/src/features/recycle_bin/presentation/bloc/recycle_bin_bloc.dart
@@ -3,7 +3,13 @@ import 'package:dr_copilot/src/features/appointments/evaluations/domain/models/e
 import 'package:dr_copilot/src/features/appointments/evaluations/domain/repositories/abstract_evaluations_repository.dart';
 import 'package:dr_copilot/src/features/appointments/sessions/domain/models/session_model.dart';
 import 'package:dr_copilot/src/features/appointments/sessions/domain/repositories/abstract_sessions_repository.dart';
+import 'package:dr_copilot/src/features/calendar_events/domain/models/calendar_event_model.dart';
+import 'package:dr_copilot/src/features/calendar_events/domain/repositories/abstract_calendar_events_repository.dart';
+import 'package:dr_copilot/src/features/patients/domain/models/patient_model.dart';
+import 'package:dr_copilot/src/features/patients/domain/repositories/abstract_patients_repository.dart';
 import 'package:equatable/equatable.dart';
+import 'package:dr_copilot/src/core/app/notifiers/owner_notifier.dart';
+import 'package:dr_copilot/src/features/auth/domain/models/permission_enum.dart';
 
 part 'recycle_bin_event.dart';
 part 'recycle_bin_state.dart';
@@ -11,10 +17,14 @@ part 'recycle_bin_state.dart';
 class RecycleBinBloc extends Bloc<RecycleBinEvent, RecycleBinState> {
   final AbstractEvaluationsRepository evaluationsRepository;
   final AbstractSessionsRepository sessionsRepository;
+  final AbstractPatientsRepository patientsRepository;
+  final AbstractCalendarEventsRepository calendarEventsRepository;
 
   RecycleBinBloc({
     required this.evaluationsRepository,
     required this.sessionsRepository,
+    required this.patientsRepository,
+    required this.calendarEventsRepository,
   }) : super(RecycleBinInitial()) {
     on<LoadDeletedItems>(_onLoadDeletedItems);
     on<RestoreItem>(_onRestoreItem);
@@ -25,15 +35,24 @@ class RecycleBinBloc extends Bloc<RecycleBinEvent, RecycleBinState> {
     LoadDeletedItems event,
     Emitter<RecycleBinState> emit,
   ) async {
+    if (!OwnerNotifier().hasPermission(AppPermission.viewRecycleBin)) {
+      emit(const RecycleBinError('Permission denied'));
+      return;
+    }
     emit(RecycleBinLoading());
 
-    // Fetch deleted items from both repositories
-    final evaluationsResult = await evaluationsRepository
-        .getDeletedEvaluations();
+    // Fetch deleted items from all repositories
+    final evaluationsResult =
+        await evaluationsRepository.getDeletedEvaluations();
     final sessionsResult = await sessionsRepository.getDeletedSessions();
+    final patientsResult = await patientsRepository.getDeletedPatients();
+    final calendarEventsResult =
+        await calendarEventsRepository.getDeletedEvents();
 
     List<EvaluationModel> evaluations = [];
     List<SessionModel> sessions = [];
+    List<PatientModel> patients = [];
+    List<CalendarEventModel> calendarEvents = [];
     String? errorMessage;
 
     evaluationsResult.fold(
@@ -42,22 +61,25 @@ class RecycleBinBloc extends Bloc<RecycleBinEvent, RecycleBinState> {
     );
 
     sessionsResult.fold(
-      (failure) => errorMessage =
-          errorMessage ?? failure.message, // Keep first error if any
+      (failure) => errorMessage = errorMessage ?? failure.message,
       (data) => sessions = data,
     );
 
-    if (errorMessage != null && evaluations.isEmpty && sessions.isEmpty) {
-      // Only show error if both failed or one failed and other is empty (and presumably failed too or just empty)
-      // If partial success, maybe show what we have? For now, let's treat any error as error state
-      // if we decide strict error handling, but usually showing partial data is better.
-      // The implementation here prefers showing data if at least one succeeded.
-      // However, the fold logic above overwrites `errorMessage`.
-      // Let's refine: if ALL fail, show error.
-    }
+    patientsResult.fold(
+      (failure) => errorMessage = errorMessage ?? failure.message,
+      (data) => patients = data,
+    );
 
-    // Check if both failed essentially (simplistic)
-    if (evaluationsResult.isLeft() && sessionsResult.isLeft()) {
+    calendarEventsResult.fold(
+      (failure) => errorMessage = errorMessage ?? failure.message,
+      (data) => calendarEvents = data,
+    );
+
+    // Check if all failed
+    if (evaluationsResult.isLeft() &&
+        sessionsResult.isLeft() &&
+        patientsResult.isLeft() &&
+        calendarEventsResult.isLeft()) {
       emit(RecycleBinError(errorMessage ?? 'Failed to load deleted items'));
       return;
     }
@@ -66,6 +88,8 @@ class RecycleBinBloc extends Bloc<RecycleBinEvent, RecycleBinState> {
       RecycleBinLoaded(
         deletedEvaluations: evaluations,
         deletedSessions: sessions,
+        deletedPatients: patients,
+        deletedCalendarEvents: calendarEvents,
       ),
     );
   }
@@ -76,6 +100,11 @@ class RecycleBinBloc extends Bloc<RecycleBinEvent, RecycleBinState> {
   ) async {
     final currentState = state;
     if (currentState is! RecycleBinLoaded) return;
+    if (!OwnerNotifier().hasPermission(AppPermission.restoreRecycleBinItem)) {
+      emit(RecycleBinError('Permission denied'));
+      add(LoadDeletedItems()); // Refresh to clear error state eventually or handle in UI
+      return;
+    }
 
     if (event.type == RecycleBinItemType.evaluation) {
       final result = await evaluationsRepository.restoreEvaluation(event.id);
@@ -83,8 +112,20 @@ class RecycleBinBloc extends Bloc<RecycleBinEvent, RecycleBinState> {
         (failure) => emit(RecycleBinError(failure.message)),
         (_) => add(LoadDeletedItems()),
       );
-    } else {
+    } else if (event.type == RecycleBinItemType.session) {
       final result = await sessionsRepository.restoreSession(event.id);
+      result.fold(
+        (failure) => emit(RecycleBinError(failure.message)),
+        (_) => add(LoadDeletedItems()),
+      );
+    } else if (event.type == RecycleBinItemType.patient) {
+      final result = await patientsRepository.restorePatient(event.id);
+      result.fold(
+        (failure) => emit(RecycleBinError(failure.message)),
+        (_) => add(LoadDeletedItems()),
+      );
+    } else if (event.type == RecycleBinItemType.calendarEvent) {
+      final result = await calendarEventsRepository.restoreEvent(event.id);
       result.fold(
         (failure) => emit(RecycleBinError(failure.message)),
         (_) => add(LoadDeletedItems()),
@@ -98,6 +139,12 @@ class RecycleBinBloc extends Bloc<RecycleBinEvent, RecycleBinState> {
   ) async {
     final currentState = state;
     if (currentState is! RecycleBinLoaded) return;
+    if (!OwnerNotifier()
+        .hasPermission(AppPermission.permanentDeleteRecycleBinItem)) {
+      emit(RecycleBinError('Permission denied'));
+      add(LoadDeletedItems());
+      return;
+    }
 
     if (event.type == RecycleBinItemType.evaluation) {
       final result = await evaluationsRepository.permanentlyDeleteEvaluation(
@@ -107,8 +154,24 @@ class RecycleBinBloc extends Bloc<RecycleBinEvent, RecycleBinState> {
         (failure) => emit(RecycleBinError(failure.message)),
         (_) => add(LoadDeletedItems()),
       );
-    } else {
+    } else if (event.type == RecycleBinItemType.session) {
       final result = await sessionsRepository.permanentlyDeleteSession(
+        event.id,
+      );
+      result.fold(
+        (failure) => emit(RecycleBinError(failure.message)),
+        (_) => add(LoadDeletedItems()),
+      );
+    } else if (event.type == RecycleBinItemType.patient) {
+      final result = await patientsRepository.permanentlyDeletePatient(
+        event.id,
+      );
+      result.fold(
+        (failure) => emit(RecycleBinError(failure.message)),
+        (_) => add(LoadDeletedItems()),
+      );
+    } else if (event.type == RecycleBinItemType.calendarEvent) {
+      final result = await calendarEventsRepository.permanentlyDeleteEvent(
         event.id,
       );
       result.fold(
@@ -118,4 +181,3 @@ class RecycleBinBloc extends Bloc<RecycleBinEvent, RecycleBinState> {
     }
   }
 }
-

--- a/lib/src/features/recycle_bin/presentation/bloc/recycle_bin_event.dart
+++ b/lib/src/features/recycle_bin/presentation/bloc/recycle_bin_event.dart
@@ -29,5 +29,4 @@ class PermanentlyDeleteItem extends RecycleBinEvent {
   List<Object?> get props => [id, type];
 }
 
-enum RecycleBinItemType { evaluation, session }
-
+enum RecycleBinItemType { evaluation, session, patient, calendarEvent }

--- a/lib/src/features/recycle_bin/presentation/bloc/recycle_bin_state.dart
+++ b/lib/src/features/recycle_bin/presentation/bloc/recycle_bin_state.dart
@@ -14,25 +14,47 @@ class RecycleBinLoading extends RecycleBinState {}
 class RecycleBinLoaded extends RecycleBinState {
   final List<EvaluationModel> deletedEvaluations;
   final List<SessionModel> deletedSessions;
+  final List<PatientModel> deletedPatients;
+  final List<CalendarEventModel> deletedCalendarEvents;
 
   const RecycleBinLoaded({
     required this.deletedEvaluations,
     required this.deletedSessions,
+    required this.deletedPatients,
+    required this.deletedCalendarEvents,
   });
 
   @override
-  List<Object?> get props => [deletedEvaluations, deletedSessions];
+  List<Object?> get props => [
+        deletedEvaluations,
+        deletedSessions,
+        deletedPatients,
+        deletedCalendarEvents,
+      ];
 
   List<dynamic> get allItems {
-    final all = [...deletedEvaluations, ...deletedSessions];
+    final all = [
+      ...deletedEvaluations,
+      ...deletedSessions,
+      ...deletedPatients,
+      ...deletedCalendarEvents,
+    ];
     // Sort by deletedAt descending
     all.sort((a, b) {
       final aTime = (a is EvaluationModel)
           ? a.deletedAt
-          : (a as SessionModel).deletedAt;
+          : (a is SessionModel)
+              ? (a as SessionModel).deletedAt
+              : (a is PatientModel)
+                  ? (a as PatientModel).deletedAt
+                  : (a as CalendarEventModel).deletedAt;
       final bTime = (b is EvaluationModel)
           ? b.deletedAt
-          : (b as SessionModel).deletedAt;
+          : (b is SessionModel)
+              ? (b as SessionModel).deletedAt
+              : (b is PatientModel)
+                  ? (b as PatientModel).deletedAt
+                  : (b as CalendarEventModel).deletedAt;
       if (aTime == null && bTime == null) return 0;
       if (aTime == null) return 1;
       if (bTime == null) return -1;
@@ -50,4 +72,3 @@ class RecycleBinError extends RecycleBinState {
   @override
   List<Object?> get props => [message];
 }
-

--- a/lib/src/features/recycle_bin/presentation/pages/recycle_bin_page.dart
+++ b/lib/src/features/recycle_bin/presentation/pages/recycle_bin_page.dart
@@ -1,10 +1,12 @@
 import 'package:dr_copilot/src/core/injections.dart';
-import 'package:dr_copilot/src/features/appointments/evaluations/domain/models/evaluation_model.dart';
-import 'package:dr_copilot/src/features/appointments/sessions/domain/models/session_model.dart';
 import 'package:dr_copilot/src/features/recycle_bin/presentation/bloc/recycle_bin_bloc.dart';
+import 'package:dr_copilot/src/features/recycle_bin/presentation/widgets/deleted_calendar_events_widget.dart';
+import 'package:dr_copilot/src/features/recycle_bin/presentation/widgets/deleted_evaluations_widget.dart';
+import 'package:dr_copilot/src/features/recycle_bin/presentation/widgets/deleted_patients_widget.dart';
+import 'package:dr_copilot/src/features/recycle_bin/presentation/widgets/deleted_sessions_widget.dart';
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:intl/intl.dart';
 
 class RecycleBinPage extends StatelessWidget {
   const RecycleBinPage({super.key});
@@ -13,141 +15,63 @@ class RecycleBinPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocProvider(
       create: (context) => sl<RecycleBinBloc>()..add(LoadDeletedItems()),
-      child: Scaffold(
-        appBar: AppBar(title: const Text('Recycle Bin')),
-        body: BlocConsumer<RecycleBinBloc, RecycleBinState>(
-          listener: (context, state) {
-            if (state is RecycleBinError) {
-              ScaffoldMessenger.of(
-                context,
-              ).showSnackBar(SnackBar(content: Text(state.message)));
-            }
-          },
-          builder: (context, state) {
-            if (state is RecycleBinLoading) {
-              return const Center(child: CircularProgressIndicator());
-            } else if (state is RecycleBinLoaded) {
-              final items = state.allItems;
-
-              if (items.isEmpty) {
-                return const Center(child: Text('Recycle Bin is empty'));
-              }
-
-              return ListView.builder(
-                itemCount: items.length,
-                itemBuilder: (context, index) {
-                  final item = items[index];
-                  return _RecycleBinItemTile(item: item);
-                },
-              );
-            }
-            return const Center(child: Text('Something went wrong'));
-          },
-        ),
-      ),
-    );
-  }
-}
-
-class _RecycleBinItemTile extends StatelessWidget {
-  final dynamic item;
-
-  const _RecycleBinItemTile({required this.item});
-
-  @override
-  Widget build(BuildContext context) {
-    final isEvaluation = item is EvaluationModel;
-    final id = isEvaluation
-        ? (item as EvaluationModel).id
-        : (item as SessionModel).id;
-    final deletedAt = isEvaluation
-        ? (item as EvaluationModel).deletedAt?.toDate()
-        : (item as SessionModel).deletedAt?.toDate();
-    final patientName = isEvaluation
-        ? (item as EvaluationModel).patientName
-        : (item as SessionModel)
-              .patientName; // Assuming SessionModel has patientName populated
-
-    // Note: SessionModel might not have patientName populated if not handled in getDeletedSessions
-    // But we did handle it in getDeletedSessions.
-
-    final title = isEvaluation ? 'Evaluation' : 'Session';
-    final subtitle =
-        'Patient: $patientName\nDeleted: ${deletedAt != null ? DateFormat('yyyy-MM-dd HH:mm').format(deletedAt) : 'Unknown'}';
-
-    return Card(
-      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-      child: ListTile(
-        leading: Icon(
-          isEvaluation ? Icons.assignment : Icons.calendar_today,
-          color: isEvaluation ? Colors.blue : Colors.green,
-        ),
-        title: Text('$title - ${id.substring(0, 5)}...'), // Shortened ID
-        subtitle: Text(subtitle),
-        trailing: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            IconButton(
-              icon: const Icon(Icons.restore),
-              tooltip: 'Restore',
-              onPressed: () {
-                context.read<RecycleBinBloc>().add(
-                  RestoreItem(
-                    id: id,
-                    type: isEvaluation
-                        ? RecycleBinItemType.evaluation
-                        : RecycleBinItemType.session,
-                  ),
-                );
-              },
-            ),
-            IconButton(
-              icon: const Icon(Icons.delete_forever, color: Colors.red),
-              tooltip: 'Delete Permanently',
-              onPressed: () {
-                _showDeleteConfirmation(context, id, isEvaluation);
-              },
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  void _showDeleteConfirmation(
-    BuildContext context,
-    String id,
-    bool isEvaluation,
-  ) {
-    showDialog(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('Delete Permanently?'),
-        content: const Text(
-          'This action cannot be undone. Are you sure you want to permanently delete this item?',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(),
-            child: const Text('Cancel'),
-          ),
-          TextButton(
-            onPressed: () {
-              Navigator.of(ctx).pop();
-              context.read<RecycleBinBloc>().add(
-                PermanentlyDeleteItem(
-                  id: id,
-                  type: isEvaluation
-                      ? RecycleBinItemType.evaluation
-                      : RecycleBinItemType.session,
+      child: DefaultTabController(
+        length: 4,
+        child: Scaffold(
+          appBar: AppBar(
+            title: Text('recycleBin'.tr()),
+            bottom: TabBar(
+              isScrollable: true,
+              tabs: [
+                Tab(
+                  icon: const Icon(Icons.people),
+                  text: 'deletedPatients'.tr(),
                 ),
-              );
-            },
-            child: const Text('Delete', style: TextStyle(color: Colors.red)),
+                Tab(
+                  icon: const Icon(Icons.calendar_today),
+                  text: 'deletedSessions'.tr(),
+                ),
+                Tab(
+                  icon: const Icon(Icons.assignment),
+                  text: 'deletedEvaluations'.tr(),
+                ),
+                Tab(
+                  icon: const Icon(Icons.event),
+                  text: 'deletedCalendarEvents'.tr(),
+                ),
+              ],
+            ),
           ),
-        ],
+          body: BlocConsumer<RecycleBinBloc, RecycleBinState>(
+            listener: (context, state) {
+              if (state is RecycleBinError) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(content: Text(state.message)),
+                );
+              }
+            },
+            builder: (context, state) {
+              if (state is RecycleBinLoading) {
+                return const Center(child: CircularProgressIndicator());
+              } else if (state is RecycleBinLoaded) {
+                return TabBarView(
+                  children: [
+                    DeletedPatientsWidget(patients: state.deletedPatients),
+                    DeletedSessionsWidget(sessions: state.deletedSessions),
+                    DeletedEvaluationsWidget(
+                      evaluations: state.deletedEvaluations,
+                    ),
+                    DeletedCalendarEventsWidget(
+                      calendarEvents: state.deletedCalendarEvents,
+                    ),
+                  ],
+                );
+              }
+              return Center(child: Text('somethingWentWrong'.tr()));
+            },
+          ),
+        ),
       ),
     );
   }
 }
-

--- a/lib/src/features/recycle_bin/presentation/widgets/deleted_calendar_events_widget.dart
+++ b/lib/src/features/recycle_bin/presentation/widgets/deleted_calendar_events_widget.dart
@@ -1,0 +1,34 @@
+import 'package:dr_copilot/src/features/calendar_events/domain/models/calendar_event_model.dart';
+
+import 'package:dr_copilot/src/features/recycle_bin/presentation/widgets/recycle_bin_item_tile.dart';
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+
+class DeletedCalendarEventsWidget extends StatelessWidget {
+  final List<CalendarEventModel> calendarEvents;
+
+  const DeletedCalendarEventsWidget({
+    super.key,
+    required this.calendarEvents,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (calendarEvents.isEmpty) {
+      return Center(
+        child: Text(
+          'noDeletedCalendarEvents'.tr(),
+          style: Theme.of(context).textTheme.bodyLarge,
+        ),
+      );
+    }
+
+    return ListView.builder(
+      itemCount: calendarEvents.length,
+      itemBuilder: (context, index) {
+        final event = calendarEvents[index];
+        return CalendarEventItemTile(event: event);
+      },
+    );
+  }
+}

--- a/lib/src/features/recycle_bin/presentation/widgets/deleted_evaluations_widget.dart
+++ b/lib/src/features/recycle_bin/presentation/widgets/deleted_evaluations_widget.dart
@@ -1,0 +1,33 @@
+import 'package:dr_copilot/src/features/appointments/evaluations/domain/models/evaluation_model.dart';
+import 'package:dr_copilot/src/features/recycle_bin/presentation/widgets/recycle_bin_item_tile.dart';
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+
+class DeletedEvaluationsWidget extends StatelessWidget {
+  final List<EvaluationModel> evaluations;
+
+  const DeletedEvaluationsWidget({
+    super.key,
+    required this.evaluations,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (evaluations.isEmpty) {
+      return Center(
+        child: Text(
+          'noDeletedEvaluations'.tr(),
+          style: Theme.of(context).textTheme.bodyLarge,
+        ),
+      );
+    }
+
+    return ListView.builder(
+      itemCount: evaluations.length,
+      itemBuilder: (context, index) {
+        final evaluation = evaluations[index];
+        return EvaluationItemTile(evaluation: evaluation);
+      },
+    );
+  }
+}

--- a/lib/src/features/recycle_bin/presentation/widgets/deleted_patients_widget.dart
+++ b/lib/src/features/recycle_bin/presentation/widgets/deleted_patients_widget.dart
@@ -1,0 +1,33 @@
+import 'package:dr_copilot/src/features/patients/domain/models/patient_model.dart';
+import 'package:dr_copilot/src/features/recycle_bin/presentation/widgets/recycle_bin_item_tile.dart';
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+
+class DeletedPatientsWidget extends StatelessWidget {
+  final List<PatientModel> patients;
+
+  const DeletedPatientsWidget({
+    super.key,
+    required this.patients,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (patients.isEmpty) {
+      return Center(
+        child: Text(
+          'noDeletedPatients'.tr(),
+          style: Theme.of(context).textTheme.bodyLarge,
+        ),
+      );
+    }
+
+    return ListView.builder(
+      itemCount: patients.length,
+      itemBuilder: (context, index) {
+        final patient = patients[index];
+        return PatientItemTile(patient: patient);
+      },
+    );
+  }
+}

--- a/lib/src/features/recycle_bin/presentation/widgets/deleted_sessions_widget.dart
+++ b/lib/src/features/recycle_bin/presentation/widgets/deleted_sessions_widget.dart
@@ -1,0 +1,34 @@
+import 'package:dr_copilot/src/features/appointments/sessions/domain/models/session_model.dart';
+import 'package:dr_copilot/src/features/recycle_bin/presentation/bloc/recycle_bin_bloc.dart';
+import 'package:dr_copilot/src/features/recycle_bin/presentation/widgets/recycle_bin_item_tile.dart';
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+
+class DeletedSessionsWidget extends StatelessWidget {
+  final List<SessionModel> sessions;
+
+  const DeletedSessionsWidget({
+    super.key,
+    required this.sessions,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (sessions.isEmpty) {
+      return Center(
+        child: Text(
+          'noDeletedSessions'.tr(),
+          style: Theme.of(context).textTheme.bodyLarge,
+        ),
+      );
+    }
+
+    return ListView.builder(
+      itemCount: sessions.length,
+      itemBuilder: (context, index) {
+        final session = sessions[index];
+        return SessionItemTile(session: session);
+      },
+    );
+  }
+}

--- a/lib/src/features/recycle_bin/presentation/widgets/recycle_bin_item_tile.dart
+++ b/lib/src/features/recycle_bin/presentation/widgets/recycle_bin_item_tile.dart
@@ -1,0 +1,326 @@
+import 'package:dr_copilot/src/features/appointments/evaluations/domain/models/evaluation_model.dart';
+import 'package:dr_copilot/src/features/appointments/sessions/domain/models/session_model.dart';
+import 'package:dr_copilot/src/features/calendar_events/domain/models/calendar_event_model.dart';
+import 'package:dr_copilot/src/features/patients/domain/models/patient_model.dart';
+import 'package:dr_copilot/src/features/recycle_bin/presentation/bloc/recycle_bin_bloc.dart';
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:intl/intl.dart';
+
+class SessionItemTile extends StatelessWidget {
+  final SessionModel session;
+
+  const SessionItemTile({super.key, required this.session});
+
+  @override
+  Widget build(BuildContext context) {
+    final deletedAt = session.deletedAt?.toDate();
+    final patientName = session.patientName;
+    final subtitle =
+        'Patient: $patientName\nDeleted: ${deletedAt != null ? DateFormat('yyyy-MM-dd HH:mm').format(deletedAt) : 'Unknown'}';
+
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: ListTile(
+        leading: const Icon(
+          Icons.calendar_today_outlined,
+          color: Colors.green,
+        ),
+        title: Text('Session - ${session.id.substring(0, 5)}...'),
+        subtitle: Text(subtitle),
+        trailing: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            IconButton(
+              icon: const Icon(Icons.restore),
+              tooltip: 'restore'.tr(),
+              onPressed: () {
+                context.read<RecycleBinBloc>().add(
+                      RestoreItem(
+                        id: session.id,
+                        type: RecycleBinItemType.session,
+                      ),
+                    );
+              },
+            ),
+            IconButton(
+              icon:
+                  const Icon(Icons.delete_forever_outlined, color: Colors.red),
+              tooltip: 'deletePermanently'.tr(),
+              onPressed: () {
+                _showDeleteConfirmation(context, session.id);
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _showDeleteConfirmation(BuildContext context, String id) {
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text('deleteConfirmation'.tr()),
+        content: Text('deleteConfirmationMessage'.tr()),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: Text('cancel'.tr()),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.of(ctx).pop();
+              context.read<RecycleBinBloc>().add(
+                    PermanentlyDeleteItem(
+                      id: id,
+                      type: RecycleBinItemType.session,
+                    ),
+                  );
+            },
+            child:
+                Text('delete'.tr(), style: const TextStyle(color: Colors.red)),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class EvaluationItemTile extends StatelessWidget {
+  final EvaluationModel evaluation;
+
+  const EvaluationItemTile({super.key, required this.evaluation});
+
+  @override
+  Widget build(BuildContext context) {
+    final deletedAt = evaluation.deletedAt?.toDate();
+    final patientName = evaluation.patientName;
+    final subtitle =
+        'Patient: $patientName\nDeleted: ${deletedAt != null ? DateFormat('yyyy-MM-dd HH:mm').format(deletedAt) : 'Unknown'}';
+
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: ListTile(
+        leading: const Icon(
+          Icons.assignment_outlined,
+          color: Colors.blue,
+        ),
+        title: Text('Evaluation - ${evaluation.id.substring(0, 5)}...'),
+        subtitle: Text(subtitle),
+        trailing: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            IconButton(
+              icon: const Icon(Icons.restore),
+              tooltip: 'restore'.tr(),
+              onPressed: () {
+                context.read<RecycleBinBloc>().add(
+                      RestoreItem(
+                        id: evaluation.id,
+                        type: RecycleBinItemType.evaluation,
+                      ),
+                    );
+              },
+            ),
+            IconButton(
+              icon:
+                  const Icon(Icons.delete_forever_outlined, color: Colors.red),
+              tooltip: 'deletePermanently'.tr(),
+              onPressed: () {
+                _showDeleteConfirmation(context, evaluation.id);
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _showDeleteConfirmation(BuildContext context, String id) {
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text('deleteConfirmation'.tr()),
+        content: Text('deleteConfirmationMessage'.tr()),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: Text('cancel'.tr()),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.of(ctx).pop();
+              context.read<RecycleBinBloc>().add(
+                    PermanentlyDeleteItem(
+                      id: id,
+                      type: RecycleBinItemType.evaluation,
+                    ),
+                  );
+            },
+            child:
+                Text('delete'.tr(), style: const TextStyle(color: Colors.red)),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class PatientItemTile extends StatelessWidget {
+  final PatientModel patient;
+
+  const PatientItemTile({super.key, required this.patient});
+
+  @override
+  Widget build(BuildContext context) {
+    final deletedAt = patient.deletedAt?.toDate();
+    final subtitle =
+        'Deleted: ${deletedAt != null ? DateFormat('yyyy-MM-dd HH:mm').format(deletedAt) : 'Unknown'}';
+
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: ListTile(
+        leading: const Icon(
+          Icons.person_outline,
+          color: Colors.orange,
+        ),
+        title: Text(patient.name ?? 'Unknown Patient'),
+        subtitle: Text(subtitle),
+        trailing: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            IconButton(
+              icon: const Icon(Icons.restore),
+              tooltip: 'restore'.tr(),
+              onPressed: () {
+                context.read<RecycleBinBloc>().add(
+                      RestoreItem(
+                        id: patient.id,
+                        type: RecycleBinItemType.patient,
+                      ),
+                    );
+              },
+            ),
+            IconButton(
+              icon:
+                  const Icon(Icons.delete_forever_outlined, color: Colors.red),
+              tooltip: 'deletePermanently'.tr(),
+              onPressed: () {
+                _showDeleteConfirmation(context, patient.id);
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _showDeleteConfirmation(BuildContext context, String id) {
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text('deleteConfirmation'.tr()),
+        content: Text('deleteConfirmationMessage'.tr()),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: Text('cancel'.tr()),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.of(ctx).pop();
+              context.read<RecycleBinBloc>().add(
+                    PermanentlyDeleteItem(
+                      id: id,
+                      type: RecycleBinItemType.patient,
+                    ),
+                  );
+            },
+            child:
+                Text('delete'.tr(), style: const TextStyle(color: Colors.red)),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class CalendarEventItemTile extends StatelessWidget {
+  final CalendarEventModel event;
+
+  const CalendarEventItemTile({super.key, required this.event});
+
+  @override
+  Widget build(BuildContext context) {
+    final deletedAt = event.deletedAt?.toDate();
+    final subtitle =
+        'Deleted: ${deletedAt != null ? DateFormat('yyyy-MM-dd HH:mm').format(deletedAt) : 'Unknown'}';
+
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: ListTile(
+        leading: const Icon(
+          Icons.event,
+          color: Colors.purple,
+        ),
+        title: Text(event.title),
+        subtitle: Text('$subtitle\n${event.startDateTime.toDate()}'),
+        trailing: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            IconButton(
+              icon: const Icon(Icons.restore),
+              tooltip: 'restore'.tr(),
+              onPressed: () {
+                context.read<RecycleBinBloc>().add(
+                      RestoreItem(
+                        id: event.id,
+                        type: RecycleBinItemType.calendarEvent,
+                      ),
+                    );
+              },
+            ),
+            IconButton(
+              icon: const Icon(Icons.delete_forever, color: Colors.red),
+              tooltip: 'deletePermanently'.tr(),
+              onPressed: () {
+                _showDeleteConfirmation(context, event.id);
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _showDeleteConfirmation(BuildContext context, String id) {
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text('deleteConfirmation'.tr()),
+        content: Text('deleteConfirmationMessage'.tr()),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: Text('cancel'.tr()),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.of(ctx).pop();
+              context.read<RecycleBinBloc>().add(
+                    PermanentlyDeleteItem(
+                      id: id,
+                      type: RecycleBinItemType.calendarEvent,
+                    ),
+                  );
+            },
+            child:
+                Text('delete'.tr(), style: const TextStyle(color: Colors.red)),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/features/settings/presentation/pages/about_page.dart
+++ b/lib/src/features/settings/presentation/pages/about_page.dart
@@ -50,7 +50,6 @@ class _AboutPageState extends State<AboutPage>
           SliverAppBar(
             expandedHeight: 220,
             pinned: true,
-
             flexibleSpace: FlexibleSpaceBar(
               background: Container(
                 decoration: BoxDecoration(
@@ -171,49 +170,49 @@ class _AboutPageState extends State<AboutPage>
   Widget _buildFeaturesTab(ThemeData theme, ColorScheme colorScheme) {
     final features = [
       {
-        'icon': Icons.people_rounded,
+        'icon': Icons.people_outline,
         'title': 'featurePatientManagement'.tr(),
         'description': 'featurePatientManagementDesc'.tr(),
         'color': Colors.blue,
       },
       {
-        'icon': Icons.calendar_today_rounded,
+        'icon': Icons.calendar_today_outlined,
         'title': 'featureAppointments'.tr(),
         'description': 'featureAppointmentsDesc'.tr(),
         'color': Colors.purple,
       },
       {
-        'icon': Icons.receipt_long_rounded,
+        'icon': Icons.receipt_long_outlined,
         'title': 'featureBilling'.tr(),
         'description': 'featureBillingDesc'.tr(),
         'color': Colors.green,
       },
       {
-        'icon': Icons.description_rounded,
+        'icon': Icons.description_outlined,
         'title': 'featureClinicalReports'.tr(),
         'description': 'featureClinicalReportsDesc'.tr(),
         'color': Colors.orange,
       },
       {
-        'icon': Icons.psychology_rounded,
+        'icon': Icons.psychology_outlined,
         'title': 'featureAiAssistant'.tr(),
         'description': 'featureAiAssistantDesc'.tr(),
         'color': Colors.pink,
       },
       {
-        'icon': Icons.chat_rounded,
+        'icon': Icons.chat_outlined,
         'title': 'featureTeamChat'.tr(),
         'description': 'featureTeamChatDesc'.tr(),
         'color': Colors.teal,
       },
       {
-        'icon': Icons.analytics_rounded,
+        'icon': Icons.analytics_outlined,
         'title': 'featureFinancials'.tr(),
         'description': 'featureFinancialsDesc'.tr(),
         'color': Colors.indigo,
       },
       {
-        'icon': Icons.cloud_rounded,
+        'icon': Icons.cloud_outlined,
         'title': 'featureIntegrations'.tr(),
         'description': 'featureIntegrationsDesc'.tr(),
         'color': Colors.cyan,
@@ -234,7 +233,7 @@ class _AboutPageState extends State<AboutPage>
               child: Row(
                 children: [
                   Icon(
-                    Icons.info_outline_rounded,
+                    Icons.info_outline,
                     size: 32,
                     color: colorScheme.primary,
                   ),
@@ -295,7 +294,7 @@ class _AboutPageState extends State<AboutPage>
                   Row(
                     children: [
                       Icon(
-                        Icons.code_rounded,
+                        Icons.code,
                         color: colorScheme.primary,
                         size: 28,
                       ),
@@ -329,7 +328,7 @@ class _AboutPageState extends State<AboutPage>
                   Row(
                     children: [
                       Icon(
-                        Icons.build_circle_rounded,
+                        Icons.build_circle_outlined,
                         color: colorScheme.primary,
                         size: 28,
                       ),
@@ -345,32 +344,32 @@ class _AboutPageState extends State<AboutPage>
                   const SizedBox(height: 20),
                   ...[
                     {
-                      'icon': Icons.flutter_dash_rounded,
+                      'icon': Icons.flutter_dash,
                       'text': 'technologyFlutter'.tr(),
                       'color': Colors.blue,
                     },
                     {
-                      'icon': Icons.whatshot_rounded,
+                      'icon': Icons.whatshot,
                       'text': 'technologyFirebase'.tr(),
                       'color': Colors.orange,
                     },
                     {
-                      'icon': Icons.stars_rounded,
+                      'icon': Icons.stars,
                       'text': 'technologyGemini'.tr(),
                       'color': Colors.purple,
                     },
                     {
-                      'icon': Icons.auto_awesome_rounded,
+                      'icon': Icons.auto_awesome_outlined,
                       'text': 'technologyOpenAI'.tr(),
                       'color': Colors.green,
                     },
                     {
-                      'icon': Icons.psychology_rounded,
+                      'icon': Icons.get_app_outlined,
                       'text': 'technologyClaude'.tr(),
                       'color': Colors.pink,
                     },
                     {
-                      'icon': Icons.cloud_queue_rounded,
+                      'icon': Icons.cloud_queue,
                       'text': 'technologyGoogleCloud'.tr(),
                       'color': Colors.cyan,
                     },
@@ -382,7 +381,8 @@ class _AboutPageState extends State<AboutPage>
                           Container(
                             padding: const EdgeInsets.all(8),
                             decoration: BoxDecoration(
-                              color: (tech['color'] as Color).withValues(alpha: 0.1),
+                              color: (tech['color'] as Color)
+                                  .withValues(alpha: 0.1),
                               borderRadius: BorderRadius.circular(8),
                             ),
                             child: Icon(
@@ -421,7 +421,7 @@ class _AboutPageState extends State<AboutPage>
                       borderRadius: BorderRadius.circular(8),
                     ),
                     child: Icon(
-                      Icons.privacy_tip_rounded,
+                      Icons.privacy_tip_outlined,
                       color: colorScheme.primary,
                     ),
                   ),
@@ -441,7 +441,7 @@ class _AboutPageState extends State<AboutPage>
                       borderRadius: BorderRadius.circular(8),
                     ),
                     child: Icon(
-                      Icons.gavel_rounded,
+                      Icons.gavel_outlined,
                       color: colorScheme.primary,
                     ),
                   ),
@@ -468,7 +468,7 @@ class _AboutPageState extends State<AboutPage>
       child: Column(
         children: [
           _ContactCard(
-            icon: Icons.email_rounded,
+            icon: Icons.email_outlined,
             title: 'contactEmailLabel'.tr(),
             value: 'contactEmailValue'.tr(),
             color: Colors.red,
@@ -483,7 +483,7 @@ class _AboutPageState extends State<AboutPage>
           ),
           const SizedBox(height: 16),
           _ContactCard(
-            icon: Icons.language_rounded,
+            icon: Icons.language_outlined,
             title: 'contactWebsiteLabel'.tr(),
             value: 'contactWebsiteValue'.tr(),
             color: Colors.blue,
@@ -498,7 +498,7 @@ class _AboutPageState extends State<AboutPage>
           ),
           const SizedBox(height: 16),
           _ContactCard(
-            icon: Icons.support_agent_rounded,
+            icon: Icons.support_agent,
             title: 'contactSupportChat'.tr(),
             value: 'messagingSupport'.tr(),
             color: Colors.green,
@@ -524,7 +524,7 @@ class _AboutPageState extends State<AboutPage>
           child: Column(
             children: [
               _SystemInfoRow(
-                icon: Icons.info_outline_rounded,
+                icon: Icons.info_outline,
                 label: 'appVersionLabel'.tr(),
                 value: _packageInfo!.version,
                 color: Colors.blue,
@@ -532,7 +532,7 @@ class _AboutPageState extends State<AboutPage>
               ),
               const Divider(height: 32),
               _SystemInfoRow(
-                icon: Icons.tag_rounded,
+                icon: Icons.tag,
                 label: 'buildNumberLabel'.tr(),
                 value: _packageInfo!.buildNumber,
                 color: Colors.purple,
@@ -540,7 +540,7 @@ class _AboutPageState extends State<AboutPage>
               ),
               const Divider(height: 32),
               _SystemInfoRow(
-                icon: Icons.devices_rounded,
+                icon: Icons.devices_other_outlined,
                 label: 'platformLabel'.tr(),
                 value: defaultTargetPlatform.name,
                 color: Colors.orange,
@@ -548,7 +548,7 @@ class _AboutPageState extends State<AboutPage>
               ),
               const Divider(height: 32),
               _SystemInfoRow(
-                icon: Icons.vpn_key_rounded,
+                icon: Icons.vpn_key_outlined,
                 label: 'App ID',
                 value: _packageInfo!.packageName,
                 color: Colors.green,
@@ -749,4 +749,3 @@ class _SystemInfoRow extends StatelessWidget {
     );
   }
 }
-

--- a/lib/src/features/settings/presentation/pages/api_key_settings_page.dart
+++ b/lib/src/features/settings/presentation/pages/api_key_settings_page.dart
@@ -20,7 +20,7 @@ class ApiKeySettingsPage extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             Icon(
-              Icons.admin_panel_settings,
+              Icons.admin_panel_settings_outlined,
               size: 64,
               color: Theme.of(context).disabledColor,
             ),

--- a/lib/src/features/settings/presentation/pages/appearance_settings_page.dart
+++ b/lib/src/features/settings/presentation/pages/appearance_settings_page.dart
@@ -94,7 +94,9 @@ class _AppearanceSettingsPageState extends State<AppearanceSettingsPage> {
                         themeNotifier.toggleTheme();
                       },
                       secondary: Icon(
-                        isDarkMode ? Icons.dark_mode : Icons.light_mode,
+                        isDarkMode
+                            ? Icons.dark_mode_outlined
+                            : Icons.light_mode_outlined,
                       ),
                     );
                   },
@@ -105,7 +107,7 @@ class _AppearanceSettingsPageState extends State<AppearanceSettingsPage> {
                   subtitle: Text(
                     _colorSchemes[themeNotifier.currentScheme] ?? 'Teal',
                   ),
-                  leading: const Icon(Icons.palette),
+                  leading: const Icon(Icons.palette_outlined),
                   trailing: const Icon(Icons.arrow_forward_ios, size: 16),
                   onTap: () => _showColorSchemeDialog(themeNotifier),
                 ),
@@ -170,7 +172,7 @@ class _AppearanceSettingsPageState extends State<AppearanceSettingsPage> {
                   title: Text(schemeName),
                   trailing: isSelected
                       ? Icon(
-                          Icons.check_circle,
+                          Icons.check_circle_outline,
                           color: Theme.of(context).colorScheme.primary,
                         )
                       : null,

--- a/lib/src/features/settings/presentation/pages/calendar_settings_page.dart
+++ b/lib/src/features/settings/presentation/pages/calendar_settings_page.dart
@@ -43,7 +43,7 @@ class CalendarSettingsPage extends StatelessWidget {
                   padding: const EdgeInsets.all(12),
                   child: Row(
                     children: [
-                      const Icon(Icons.lock, color: Colors.orange),
+                      const Icon(Icons.lock_outline, color: Colors.orange),
                       const SizedBox(width: 8),
                       Expanded(
                         child: Text(

--- a/lib/src/features/settings/presentation/pages/copilot_preferences_page.dart
+++ b/lib/src/features/settings/presentation/pages/copilot_preferences_page.dart
@@ -28,7 +28,7 @@ class CopilotPreferencesPage extends StatelessWidget {
                   padding: const EdgeInsets.all(12),
                   child: Row(
                     children: [
-                      const Icon(Icons.lock, color: Colors.orange),
+                      const Icon(Icons.lock_outline, color: Colors.orange),
                       const SizedBox(width: 8),
                       Expanded(
                         child: Text(

--- a/lib/src/features/settings/presentation/pages/data_storage_settings_page.dart
+++ b/lib/src/features/settings/presentation/pages/data_storage_settings_page.dart
@@ -47,14 +47,14 @@ class _DataStorageSettingsPageState extends State<DataStorageSettingsPage> {
         children: [
           ListTile(
             title: const Text('clearAppCache').tr(),
-            leading: const Icon(Icons.cleaning_services),
+            leading: const Icon(Icons.cleaning_services_outlined),
             onTap: _clearAppCache,
           ),
           const Divider(),
           ListTile(
             title: const Text('exportMyData').tr(),
             subtitle: const Text('exportMyDataDescription').tr(),
-            leading: const Icon(Icons.download),
+            leading: const Icon(Icons.download_outlined),
             onTap: () => context.push('/settings/export_data'),
           ),
         ],
@@ -62,4 +62,3 @@ class _DataStorageSettingsPageState extends State<DataStorageSettingsPage> {
     );
   }
 }
-

--- a/lib/src/features/settings/presentation/pages/export_data_page.dart
+++ b/lib/src/features/settings/presentation/pages/export_data_page.dart
@@ -134,7 +134,7 @@ class _ExportDataBodyState extends State<_ExportDataBody> {
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
               Icon(
-                Icons.lock_outline_rounded,
+                Icons.lock_outline,
                 size: 64,
                 color: Theme.of(context).colorScheme.outline,
               ),
@@ -153,7 +153,7 @@ class _ExportDataBodyState extends State<_ExportDataBody> {
               const SizedBox(height: 32),
               FilledButton.icon(
                 onPressed: () => context.push('/subscription_pricing'),
-                icon: const Icon(Icons.star),
+                icon: const Icon(Icons.star_border),
                 label: Text('upgrade'.tr()),
               ),
             ],
@@ -190,7 +190,7 @@ class _ExportDataBodyState extends State<_ExportDataBody> {
                       Row(
                         children: [
                           Icon(
-                            Icons.download_rounded,
+                            Icons.download_outlined,
                             size: 32,
                             color: Theme.of(context).colorScheme.primary,
                           ),
@@ -229,37 +229,37 @@ class _ExportDataBodyState extends State<_ExportDataBody> {
                     children: [
                       _buildIncludedItem(
                         context,
-                        Icons.person,
+                        Icons.person_outline,
                         'userProfile'.tr(),
                       ),
                       _buildIncludedItem(
                         context,
-                        Icons.people,
+                        Icons.people_outline,
                         'patientsAndDoctors'.tr(),
                       ),
                       _buildIncludedItem(
                         context,
-                        Icons.description,
+                        Icons.description_outlined,
                         'clinicalReports'.tr(),
                       ),
                       _buildIncludedItem(
                         context,
-                        Icons.event,
+                        Icons.event_outlined,
                         'sessionsAndEvaluations'.tr(),
                       ),
                       _buildIncludedItem(
                         context,
-                        Icons.attach_money,
+                        Icons.monetization_on_outlined,
                         'financialRecords'.tr(),
                       ),
                       _buildIncludedItem(
                         context,
-                        Icons.chat,
+                        Icons.chat_outlined,
                         'copilotConversations'.tr(),
                       ),
                       _buildIncludedItem(
                         context,
-                        Icons.notifications,
+                        Icons.notifications_outlined,
                         'notifications'.tr(),
                         isLast: true,
                       ),
@@ -296,7 +296,9 @@ class _ExportDataBodyState extends State<_ExportDataBody> {
                             ),
                             Text(
                               '${(state.progress * 100).toStringAsFixed(0)}%',
-                              style: Theme.of(context).textTheme.bodyMedium
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .bodyMedium
                                   ?.copyWith(fontWeight: FontWeight.bold),
                             ),
                           ],
@@ -311,12 +313,12 @@ class _ExportDataBodyState extends State<_ExportDataBody> {
                         const SizedBox(height: 8),
                         Text(
                           state.currentCategory,
-                          style: Theme.of(context).textTheme.bodySmall
-                              ?.copyWith(
-                                color: Theme.of(
-                                  context,
-                                ).colorScheme.onSurfaceVariant,
-                              ),
+                          style:
+                              Theme.of(context).textTheme.bodySmall?.copyWith(
+                                    color: Theme.of(
+                                      context,
+                                    ).colorScheme.onSurfaceVariant,
+                                  ),
                         ),
                       ],
                     ),
@@ -336,7 +338,7 @@ class _ExportDataBodyState extends State<_ExportDataBody> {
                         Row(
                           children: [
                             Icon(
-                              Icons.check_circle,
+                              Icons.check_circle_outline,
                               color: Theme.of(context).colorScheme.primary,
                               size: 32,
                             ),
@@ -344,7 +346,9 @@ class _ExportDataBodyState extends State<_ExportDataBody> {
                             Expanded(
                               child: Text(
                                 'exportSuccess'.tr(),
-                                style: Theme.of(context).textTheme.titleMedium
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .titleMedium
                                     ?.copyWith(
                                       color: Theme.of(
                                         context,
@@ -359,12 +363,12 @@ class _ExportDataBodyState extends State<_ExportDataBody> {
                           'exportSuccessDescription'.tr(
                             args: [_formatBytes(state.fileSize)],
                           ),
-                          style: Theme.of(context).textTheme.bodyMedium
-                              ?.copyWith(
-                                color: Theme.of(
-                                  context,
-                                ).colorScheme.onPrimaryContainer,
-                              ),
+                          style:
+                              Theme.of(context).textTheme.bodyMedium?.copyWith(
+                                    color: Theme.of(
+                                      context,
+                                    ).colorScheme.onPrimaryContainer,
+                                  ),
                         ),
                         const SizedBox(height: 16),
                         Wrap(
@@ -373,12 +377,12 @@ class _ExportDataBodyState extends State<_ExportDataBody> {
                           children: [
                             FilledButton.icon(
                               onPressed: () => _openFile(state.filePath),
-                              icon: const Icon(Icons.folder_open),
+                              icon: const Icon(Icons.folder_open_outlined),
                               label: Text('openFile'.tr()),
                             ),
                             OutlinedButton.icon(
                               onPressed: () => _shareFile(state.filePath),
-                              icon: const Icon(Icons.share),
+                              icon: const Icon(Icons.share_outlined),
                               label: Text('share'.tr()),
                             ),
                           ],
@@ -398,8 +402,8 @@ class _ExportDataBodyState extends State<_ExportDataBody> {
                       ? null
                       : () {
                           context.read<ExportBloc>().add(
-                            const ExportDataRequested(),
-                          );
+                                const ExportDataRequested(),
+                              );
                         },
                   icon: state is ExportInProgress
                       ? const SizedBox(
@@ -410,13 +414,13 @@ class _ExportDataBodyState extends State<_ExportDataBody> {
                             color: Colors.white,
                           ),
                         )
-                      : const Icon(Icons.download),
+                      : const Icon(Icons.download_outlined),
                   label: Text(
                     state is ExportInProgress
                         ? 'exporting'.tr()
                         : state is ExportSuccess
-                        ? 'exportAgain'.tr()
-                        : 'startExport'.tr(),
+                            ? 'exportAgain'.tr()
+                            : 'startExport'.tr(),
                   ),
                   style: FilledButton.styleFrom(
                     padding: const EdgeInsets.symmetric(vertical: 16),
@@ -442,12 +446,12 @@ class _ExportDataBodyState extends State<_ExportDataBody> {
                       Expanded(
                         child: Text(
                           'exportLegalNotice'.tr(),
-                          style: Theme.of(context).textTheme.bodySmall
-                              ?.copyWith(
-                                color: Theme.of(
-                                  context,
-                                ).colorScheme.onSurfaceVariant,
-                              ),
+                          style:
+                              Theme.of(context).textTheme.bodySmall?.copyWith(
+                                    color: Theme.of(
+                                      context,
+                                    ).colorScheme.onSurfaceVariant,
+                                  ),
                         ),
                       ),
                     ],
@@ -524,4 +528,3 @@ class _ExportDataBodyState extends State<_ExportDataBody> {
     }
   }
 }
-

--- a/lib/src/features/settings/presentation/pages/model_selection_page.dart
+++ b/lib/src/features/settings/presentation/pages/model_selection_page.dart
@@ -214,7 +214,7 @@ class _ModelSelectionPageState extends State<ModelSelectionPage> {
             groupValue: _selectedActiveModel,
             onChanged: _setActiveModel,
             secondary: isSelected
-                ? Icon(Icons.check_circle,
+                ? Icon(Icons.check_circle_outline,
                     color: Theme.of(context).colorScheme.primary)
                 : null,
           );

--- a/lib/src/features/settings/presentation/pages/settings_page.dart
+++ b/lib/src/features/settings/presentation/pages/settings_page.dart
@@ -40,7 +40,7 @@ class _SettingsPageState extends State<SettingsPage> {
     return Scaffold(
       appBar: AppBar(
         title: Text('settings'.tr()),
-        leading: const Icon(Icons.settings),
+        leading: const Icon(Icons.settings_outlined),
         actions: [navMenuButton ?? const SizedBox()],
         backgroundColor: Theme.of(context).colorScheme.surface,
         elevation: 0.5,
@@ -51,7 +51,7 @@ class _SettingsPageState extends State<SettingsPage> {
             children: <Widget>[
               _buildSectionHeader('general'),
               ListTile(
-                leading: const Icon(Icons.language),
+                leading: const Icon(Icons.language_outlined),
                 title: Text('language'.tr()),
                 trailing: DropdownButtonHideUnderline(
                   child: DropdownButton<String>(
@@ -69,7 +69,7 @@ class _SettingsPageState extends State<SettingsPage> {
                         value: 'en',
                         child: Row(
                           children: [
-                            Icon(Icons.language, color: Colors.blue),
+                            Icon(Icons.language_outlined, color: Colors.blue),
                             SizedBox(width: 8),
                             Text('language_en'.tr()),
                           ],
@@ -79,7 +79,7 @@ class _SettingsPageState extends State<SettingsPage> {
                         value: 'ar',
                         child: Row(
                           children: [
-                            Icon(Icons.language, color: Colors.green),
+                            Icon(Icons.language_outlined, color: Colors.green),
                             SizedBox(width: 8),
                             Text('language_ar'.tr()),
                           ],
@@ -109,13 +109,13 @@ class _SettingsPageState extends State<SettingsPage> {
                 ),
               ),
               ListTile(
-                leading: const Icon(Icons.palette),
+                leading: const Icon(Icons.palette_outlined),
                 title: Text('appearance'.tr()),
                 onTap: () => context.push('/settings/appearance'),
               ),
               _buildSectionHeader('Copilot Intelligence'),
               ListTile(
-                leading: const Icon(Icons.psychology),
+                leading: const Icon(Icons.psychology_outlined),
                 title: const Text('Copilot Preferences'),
                 subtitle: const Text(
                     'Configure required fields for AI (Patients, Sessions, Evaluations)'),
@@ -124,12 +124,12 @@ class _SettingsPageState extends State<SettingsPage> {
               ),
               _buildSectionHeader('appSettings'),
               ListTile(
-                leading: const Icon(Icons.notifications),
+                leading: const Icon(Icons.notifications_outlined),
                 title: Text('notifications'.tr()),
                 onTap: () => context.push('/settings/notifications'),
               ),
               ListTile(
-                leading: const Icon(Icons.date_range),
+                leading: const Icon(Icons.date_range_outlined),
                 title: Text('Calendar Settings'),
                 onTap: () => context.push('/settings/calendar_settings'),
               ),
@@ -140,33 +140,33 @@ class _SettingsPageState extends State<SettingsPage> {
               ),
               _buildSectionHeader('accountAndSecurity'),
               ListTile(
-                leading: const Icon(Icons.card_membership),
+                leading: const Icon(Icons.card_membership_outlined),
                 title: Text('subscriptionAndBilling'.tr()),
                 onTap: () => context.push('/settings/subscription'),
               ),
               ListTile(
-                leading: const Icon(Icons.security),
+                leading: const Icon(Icons.security_outlined),
                 title: Text('security'.tr()),
                 onTap: () => context.push('/settings/security'),
               ),
               ListTile(
-                leading: const Icon(Icons.model_training),
+                leading: const Icon(Icons.model_training_outlined),
                 title: Text('aiModel'.tr()),
                 onTap: () => context.push('/settings/model_selection'),
               ),
               ListTile(
-                leading: const Icon(Icons.lock),
+                leading: const Icon(Icons.lock_outline),
                 title: Text('privacy'.tr()),
                 onTap: () => context.push('/privacy'),
               ),
               _buildSectionHeader('support'),
               ListTile(
-                leading: const Icon(Icons.help),
+                leading: const Icon(Icons.help_outline),
                 title: Text('helpSupport'.tr()),
                 onTap: () => context.push('/help_support'),
               ),
               ListTile(
-                leading: const Icon(Icons.info),
+                leading: const Icon(Icons.info_outline),
                 title: Text('about'.tr()),
                 onTap: () => context.push('/about'),
               ),

--- a/lib/src/features/staff/data/remote/staff_firebase_api.dart
+++ b/lib/src/features/staff/data/remote/staff_firebase_api.dart
@@ -1,11 +1,16 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:dr_copilot/src/core/error/exceptions.dart';
+import 'package:dr_copilot/src/core/app/notifiers/owner_notifier.dart';
+import 'package:dr_copilot/src/features/auth/domain/models/permission_enum.dart';
 import 'package:dr_copilot/src/features/staff/domain/models/staff_model.dart';
 
 class StaffFirebaseApi {
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
 
   Future<void> addStaff(StaffModel staff) async {
+    if (!OwnerNotifier().hasPermission(AppPermission.manageStaff)) {
+      throw ServerException('Permission denied', 403);
+    }
     try {
       await _firestore.collection('staff').doc(staff.id).set(staff.toJson());
     } catch (e) {
@@ -14,6 +19,9 @@ class StaffFirebaseApi {
   }
 
   Future<StaffModel> getStaff(String staffId) async {
+    if (!OwnerNotifier().hasPermission(AppPermission.manageStaff)) {
+      throw ServerException('Permission denied', 403);
+    }
     try {
       final doc = await _firestore.collection('staff').doc(staffId).get();
       if (!doc.exists) {
@@ -26,6 +34,9 @@ class StaffFirebaseApi {
   }
 
   Future<List<StaffModel>> getAllStaff({required String clinicId}) async {
+    if (!OwnerNotifier().hasPermission(AppPermission.manageStaff)) {
+      throw ServerException('Permission denied', 403);
+    }
     try {
       final snapshot = await _firestore
           .collection('staff')
@@ -38,6 +49,9 @@ class StaffFirebaseApi {
   }
 
   Future<void> updateStaff(String staffId, StaffModel staff) async {
+    if (!OwnerNotifier().hasPermission(AppPermission.manageStaff)) {
+      throw ServerException('Permission denied', 403);
+    }
     try {
       await _firestore.collection('staff').doc(staffId).update(staff.toJson());
     } catch (e) {
@@ -46,6 +60,9 @@ class StaffFirebaseApi {
   }
 
   Future<void> deleteStaff(String staffId) async {
+    if (!OwnerNotifier().hasPermission(AppPermission.manageStaff)) {
+      throw ServerException('Permission denied', 403);
+    }
     try {
       await _firestore.collection('staff').doc(staffId).delete();
     } catch (e) {
@@ -53,4 +70,3 @@ class StaffFirebaseApi {
     }
   }
 }
-

--- a/lib/src/features/subscription/domain/services/subscription_service.dart
+++ b/lib/src/features/subscription/domain/services/subscription_service.dart
@@ -138,7 +138,7 @@ class SubscriptionService {
 
       // Also count pending invitations?
       final pendingInvites = await _firestore
-          .collection('invitations')
+          .collection('user_invitations')
           .where('clinicId', isEqualTo: clinicId)
           .where('status', isEqualTo: 'pending')
           .where('roles', arrayContains: role)

--- a/lib/src/features/team_chat/data/repositories/team_chat_repository.dart
+++ b/lib/src/features/team_chat/data/repositories/team_chat_repository.dart
@@ -6,7 +6,7 @@ class TeamChatRepository {
   final FirebaseFirestore _firestore;
 
   TeamChatRepository({FirebaseFirestore? firestore})
-    : _firestore = firestore ?? FirebaseFirestore.instance;
+      : _firestore = firestore ?? FirebaseFirestore.instance;
 
   /// Get all active conversations for a specific user
   Stream<List<TeamConversationModel>> getConversations(String userId) {
@@ -16,10 +16,10 @@ class TeamChatRepository {
         .orderBy('updatedAt', descending: true)
         .snapshots()
         .map((snapshot) {
-          return snapshot.docs
-              .map((doc) => TeamConversationModel.fromFirestore(doc))
-              .toList();
-        });
+      return snapshot.docs
+          .map((doc) => TeamConversationModel.fromFirestore(doc))
+          .toList();
+    });
   }
 
   /// Get messages for a specific conversation
@@ -31,10 +31,10 @@ class TeamChatRepository {
         .orderBy('timestamp', descending: false)
         .snapshots()
         .map((snapshot) {
-          return snapshot.docs
-              .map((doc) => TeamMessageModel.fromFirestore(doc))
-              .toList();
-        });
+      return snapshot.docs
+          .map((doc) => TeamMessageModel.fromFirestore(doc))
+          .toList();
+    });
   }
 
   /// Send a message to a conversation
@@ -67,9 +67,8 @@ class TeamChatRepository {
     batch.set(messageRef, message.toFirestore());
 
     // 2. Update conversation last message details
-    final conversationRef = _firestore
-        .collection('team_conversations')
-        .doc(conversationId);
+    final conversationRef =
+        _firestore.collection('team_conversations').doc(conversationId);
 
     batch.update(conversationRef, {
       'lastMessage': type == MessageType.text ? content : '[Image]',
@@ -88,6 +87,12 @@ class TeamChatRepository {
     required String currentUserId,
     required String targetUserId,
   }) async {
+    // Starting a chat is available to all staff, but ideally checked against clinic membership.
+    // Since this is 1:1, basic membership (implicit) is usually enough,
+    // but strict mode might require `manageTeams` or similar. Keeping it open for now as 'chat' is basic.
+    // However, if we wanted strictness:
+    // if (!OwnerNotifier().hasPermission(AppPermission.manageTeams)) throw Exception('...');
+
     // 1. Check if 1-on-1 chat already exists
     // We need to find conversations with exactly 2 participants AND no teamId in metadata
     final querySnapshot = await _firestore
@@ -150,4 +155,3 @@ class TeamChatRepository {
     }
   }
 }
-

--- a/lib/src/features/team_chat/presentation/pages/team_chat_list_page.dart
+++ b/lib/src/features/team_chat/presentation/pages/team_chat_list_page.dart
@@ -80,7 +80,7 @@ class TeamChatListPage extends StatelessWidget {
 
 class _ConversationTile extends StatelessWidget {
   final dynamic
-  conversation; // Can be TeamConversationModel or DirectConversationModel
+      conversation; // Can be TeamConversationModel or DirectConversationModel
   final String currentUserId;
 
   const _ConversationTile({
@@ -118,14 +118,14 @@ class _ConversationTile extends StatelessWidget {
     return ListTile(
       leading: CircleAvatar(
         child: isDirectMessage
-            ? const Icon(Icons.person)
-            : const Icon(Icons.group),
+            ? const Icon(Icons.person_outline)
+            : const Icon(Icons.group_outlined),
       ),
       title: Text(
         isDirectMessage
             ? otherUserId // Direct message - show other user
             : (conversation as TeamConversationModel).metadata['teamName'] ??
-                  'Team Chat',
+                'Team Chat',
       ),
       subtitle: lastMessage != null
           ? Text(lastMessage, maxLines: 1, overflow: TextOverflow.ellipsis)
@@ -157,4 +157,3 @@ class _ConversationTile extends StatelessWidget {
     }
   }
 }
-

--- a/lib/src/features/team_chat/presentation/widgets/team_chat_list_view.dart
+++ b/lib/src/features/team_chat/presentation/widgets/team_chat_list_view.dart
@@ -17,7 +17,7 @@ class TeamChatListView extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Team Chat'),
-        leading: const Icon(Icons.chat),
+        leading: const Icon(Icons.chat_outlined),
       ),
       floatingActionButton: onAddChat != null
           ? FloatingActionButton(
@@ -53,8 +53,8 @@ class TeamChatListView extends StatelessWidget {
                 return ListTile(
                   leading: CircleAvatar(
                     child: conversation.isDirectMessage
-                        ? const Icon(Icons.person)
-                        : const Icon(Icons.group),
+                        ? const Icon(Icons.person_outline)
+                        : const Icon(Icons.group_outlined),
                   ),
                   title: Text(conversation.title),
                   subtitle: conversation.lastMessage != null

--- a/lib/src/features/teams/domain/models/custom_team_model.g.dart
+++ b/lib/src/features/teams/domain/models/custom_team_model.g.dart
@@ -12,9 +12,8 @@ CustomTeamModel _$CustomTeamModelFromJson(Map<String, dynamic> json) =>
       clinicId: json['clinicId'] as String,
       ownerId: json['ownerId'] as String,
       name: json['name'] as String,
-      memberIds: (json['memberIds'] as List<dynamic>)
-          .map((e) => e as String)
-          .toList(),
+      memberIds:
+          (json['memberIds'] as List<dynamic>).map((e) => e as String).toList(),
       isArchived: json['isArchived'] as bool? ?? false,
       createdAt: CustomTeamModel._timestampFromJson(json['createdAt']),
     );
@@ -29,4 +28,3 @@ Map<String, dynamic> _$CustomTeamModelToJson(CustomTeamModel instance) =>
       'isArchived': instance.isArchived,
       'createdAt': CustomTeamModel._timestampToJson(instance.createdAt),
     };
-

--- a/lib/src/features/teams/presentation/pages/teams_dashboard_page.dart
+++ b/lib/src/features/teams/presentation/pages/teams_dashboard_page.dart
@@ -43,8 +43,8 @@ class _TeamsDashboardPageState extends State<TeamsDashboardPage> {
     final authState = context.read<AuthBloc>().state;
     if (authState is AuthSignedIn && authState.user?.primaryClinicId != null) {
       context.read<TeamsBloc>().add(
-        LoadTeamsEvent(clinicId: authState.user!.primaryClinicId!),
-      );
+            LoadTeamsEvent(clinicId: authState.user!.primaryClinicId!),
+          );
     }
   }
 
@@ -85,7 +85,8 @@ class _TeamsDashboardPageState extends State<TeamsDashboardPage> {
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
-                    Icon(Icons.group_off, size: 64, color: Colors.grey[400]),
+                    Icon(Icons.group_off_outlined,
+                        size: 64, color: Colors.grey[400]),
                     const SizedBox(height: 16),
                     Text(
                       'noTeamsYet'.tr(),
@@ -120,7 +121,7 @@ class _TeamsDashboardPageState extends State<TeamsDashboardPage> {
                       mainAxisSize: MainAxisSize.min,
                       children: [
                         IconButton(
-                          icon: const Icon(Icons.chat),
+                          icon: const Icon(Icons.chat_outlined),
                           onPressed: () => _startTeamChat(context, team),
                           tooltip: 'startChat'.tr(),
                         ),
@@ -130,7 +131,7 @@ class _TeamsDashboardPageState extends State<TeamsDashboardPage> {
                               value: 'edit',
                               child: Row(
                                 children: [
-                                  const Icon(Icons.edit),
+                                  const Icon(Icons.edit_outlined),
                                   const SizedBox(width: 8),
                                   Text('edit'.tr()),
                                 ],
@@ -144,7 +145,7 @@ class _TeamsDashboardPageState extends State<TeamsDashboardPage> {
                                 child: Row(
                                   children: [
                                     const Icon(
-                                      Icons.archive,
+                                      Icons.archive_outlined,
                                       color: Colors.orange,
                                     ),
                                     const SizedBox(width: 8),
@@ -193,28 +194,28 @@ class _TeamsDashboardPageState extends State<TeamsDashboardPage> {
       ),
       floatingActionButton:
           OwnerNotifier().hasPermission(AppPermission.createTeam)
-          ? FloatingActionButton.extended(
-              onPressed: () async {
-                final teamsBloc = context.read<TeamsBloc>();
-                final result = await Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (context) => BlocProvider.value(
-                      value: teamsBloc,
-                      child: const CreateEditTeamPage(),
-                    ),
-                  ),
-                );
+              ? FloatingActionButton.extended(
+                  onPressed: () async {
+                    final teamsBloc = context.read<TeamsBloc>();
+                    final result = await Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => BlocProvider.value(
+                          value: teamsBloc,
+                          child: const CreateEditTeamPage(),
+                        ),
+                      ),
+                    );
 
-                // Reload teams if a team was created/updated
-                if (result == true) {
-                  _loadTeams();
-                }
-              },
-              icon: const Icon(Icons.add),
-              label: Text('createTeam'.tr()),
-            )
-          : null,
+                    // Reload teams if a team was created/updated
+                    if (result == true) {
+                      _loadTeams();
+                    }
+                  },
+                  icon: const Icon(Icons.add),
+                  label: Text('createTeam'.tr()),
+                )
+              : null,
     );
   }
 
@@ -274,12 +275,12 @@ class _TeamsDashboardPageState extends State<TeamsDashboardPage> {
             .collection('team_conversations')
             .doc(conversationId)
             .set({
-              'clinicId': team.clinicId,
-              'participantIds': team.memberIds,
-              'createdAt': Timestamp.now(),
-              'updatedAt': Timestamp.now(),
-              'metadata': {'teamId': team.id, 'teamName': team.name},
-            });
+          'clinicId': team.clinicId,
+          'participantIds': team.memberIds,
+          'createdAt': Timestamp.now(),
+          'updatedAt': Timestamp.now(),
+          'metadata': {'teamId': team.id, 'teamName': team.name},
+        });
       }
 
       if (context.mounted) {
@@ -298,4 +299,3 @@ class _TeamsDashboardPageState extends State<TeamsDashboardPage> {
     }
   }
 }
-

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.2+1
+version: 1.0.3+1
 
 environment:
   sdk: '>=3.5.0 <5.0.0'
@@ -114,6 +114,7 @@ dependencies:
   local_auth: ^3.0.0
   timeago: ^3.7.1
   in_app_purchase: ^3.2.3
+  firebase_remote_config: ^6.1.3
 
 dependency_overrides:
   speech_to_text_windows:
@@ -145,6 +146,7 @@ dev_dependencies:
   fake_cloud_firestore: ^4.0.0
   firebase_auth_mocks: ^0.15.1
   msix: ^3.16.7
+  image: ^4.7.2
 
 
 # For information on the generic Dart part of this file, see the


### PR DESCRIPTION
## Summary
Fixed critical 'Permission Denied' errors by centralizing permission management into \PermissionService\.

## Changes
- **Permission Service**: Centralized check logic, added 5-minute caching.
- **OwnerNotifier**: Delegates to \PermissionService\ (backward compatible).
- **Firestore Rules**: Added security rules for \conversations\ and \custom_teams\.
- **Cleaned**: Removed \pply-universal-permissions.js\ to resolve security scanning blocks.
- **Version**: Bumped to \1.0.3+1\.

## Verification
- Admin accessing Chat History, Teams, Bills works correctly.
- Permissions cached to reduce Firestore reads.